### PR TITLE
Rename genome directory and references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ When submitting PRs:
 -   Write clear descriptions\
 -   Include rationale when changing core behavior\
 -   Add tests when adding logic to the genome engine\
--   Follow Kotlin idioms and keep `genome-core` free of
-    simulator-specific dependencies
+-   Follow Kotlin idioms and keep `genome` free of simulator-specific
+    dependencies
 
 PRs may be revised for consistency with the project's long-term
 direction.
@@ -64,7 +64,7 @@ direction.
 
 ## 🧬 Code Style and Structure
 
-### Genome Core (`genome-core`)
+### Genome (`genome`)
 
 -   **Pure logic only**: No references to rendering, physics, or
     simulation types\

--- a/README.md
+++ b/README.md
@@ -58,15 +58,16 @@ question:
 
 ------------------------------------------------------------------------
 
-## 🧬 Project Structure (planned)
+## 🧬 Project Structure
 
     life-sim/
-    ├─ genome-core/      # Genome representation, parsing, gene interfaces, mutations
+    ├─ genome/           # Genome representation, parsing, gene interfaces, mutations
     ├─ simulator/        # World model, physics, rendering, organism lifecycle
     └─ docs/             # Architecture notes, gene specs, dev logs (optional)
 
-Keeping these separate makes it possible to reuse `genome-core` for
-future experiments.
+Keeping these separate makes it possible to reuse `genome` for
+future experiments. Each directory includes a short README with planned
+components to guide initial contributions.
 
 ------------------------------------------------------------------------
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+The documentation space collects architecture notes, gene specifications, and development logs. Use this area to capture design decisions, experiment results, and outlines for future work.
+
+Suggested subfolders:
+- `architecture/` for diagrams and module overviews
+- `genes/` for gene specifications and behaviors
+- `logs/` for dev journals and experiment notes
+- `references/` for external research links and summaries

--- a/genome/README.md
+++ b/genome/README.md
@@ -1,0 +1,9 @@
+# Genome
+
+This package will house the core genome logic, including byte-encoded genome definitions, gene interfaces, mutation utilities, and serialization helpers. It is intended to stay lightweight and reusable so experiments can import the genome layer independently from the simulator.
+
+Planned components:
+- Genome byte format and parsing utilities
+- Gene definition interfaces and registration
+- Mutation operators and validation helpers
+- Unit tests for genome parsing and mutations

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -1,0 +1,10 @@
+# Simulator
+
+The simulator will model the world, organisms, and rendering pipeline. It brings together the genome package, physics, resource dynamics, and visualization to run full life-sim experiments.
+
+Planned components:
+- World state, physics, and tick loop
+- Organism lifecycle management (spawn, update, death)
+- Interaction with genome outputs to build organisms
+- Rendering hooks for debugging and visualization
+- Configuration and experiment orchestration tools


### PR DESCRIPTION
## Summary
- rename the `genome-core` directory to `genome`
- update project and contributing guides to reference the new `genome` path
- refresh simulator README wording to match the renamed genome package

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c0c6167248329867959266acc4458)