### PR TITLE
Add biology primitives and molecules documentation and update docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,9 @@ Suggested subfolders:
 - `genes/` for gene, regulatory, or heredity specifications
 - `logs/` for dev journals and experiment notes
 - `references/` for external research links and summaries
+
+
+Current biology docs:
+- `biology/primitives.md`
+- `biology/molecules.md`
+- `biology/interactions/bonds.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,6 @@ Suggested subfolders:
 - `logs/` for dev journals and experiment notes
 - `references/` for external research links and summaries
 
-
 Current biology docs:
 - `biology/primitives.md`
 - `biology/molecules.md`

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -1,0 +1,109 @@
+# Molecules
+
+This document describes the molecule-level types in `life.sim.biology.molecules`.
+
+These types wrap primitive nucleotide sequences with biological meaning, while keeping data structures compact and immutable.
+
+---
+
+## Overview
+
+Current molecule types:
+
+- `Dna` — double-stranded DNA-like duplex
+- `MRna` — messenger RNA wrapper
+- `TRna` — transfer RNA wrapper with complementary scanning support
+
+The current biology model uses the shared RNA nucleotide alphabet (`A`, `C`, `G`, `U`) across all molecule types.
+
+---
+
+## `Dna`
+
+`Dna` represents a duplex with two strands:
+
+- `forward: NucleotideSequence`
+- `reverse: NucleotideSequence`
+
+### Invariants
+
+`Dna.of(...)` normalizes and validates both strands:
+
+- forward strand direction is normalized to `FORWARD`
+- reverse strand direction is normalized to `BACKWARD`
+- both strands must have equal length
+- each index must be complementary (`A<->U`, `C<->G`)
+
+If any invariant fails, construction throws `IllegalArgumentException`.
+
+### Constructors and parsing
+
+- `empty()` creates a zero-length duplex
+- `of(forward, reverse = forward.complement())`
+- `of(forwardText, reverseText)`
+- `of(text)` / `parse(text)`
+
+Text parsing supports one or two lines:
+
+- one line: parses forward and auto-generates reverse complement
+- two lines: parses both and validates complementarity
+
+`toString()` serializes DNA as two lines (`forward` then `reverse`).
+
+---
+
+## `MRna`
+
+`MRna` is a lightweight inline wrapper around `NucleotideSequence`.
+
+Purpose:
+
+- preserve type-level distinction from other RNA species
+- keep APIs explicit at call sites
+
+Core operations:
+
+- `size`, `isEmpty()`
+- `toNucleotideSequence()`
+- `complement()`
+- `toString()`
+- factories: `empty()`, `of(sequence)`, `of(text)`, `parse(text)`
+
+---
+
+## `TRna`
+
+`TRna` is also a lightweight inline wrapper around `NucleotideSequence`, with one extra behavior for binding-style matching.
+
+Core operations:
+
+- `size`, `isEmpty()`
+- `toNucleotideSequence()`
+- `toString()`
+- factories: `empty()`, `of(sequence)`, `of(text)`, `parse(text)`
+
+Binding-specific helper:
+
+- `scan(target: NucleotideSequence): Int`
+
+`scan(...)` delegates to `BindingMatcher.complementaryMatchStart(...)`, so matching is based on **complementary pairing rules** rather than direct nucleotide equality.
+
+---
+
+## Relationship to interactions
+
+Molecule values describe structural identity.
+
+Runtime occupancy and binding state are modeled separately by the interactions layer (`BindingSurface`, `BindingSite`, `Bond`, `BondRegistry`).
+
+That separation allows molecule values to remain immutable while runtime systems track transient binding dynamics.
+
+---
+
+## Example usage pattern
+
+1. Build or parse molecules (`Dna`, `MRna`, `TRna`)
+2. Extract `NucleotideSequence` when low-level operations are needed
+3. Use interaction APIs to represent where and what is bound at runtime
+
+This keeps the molecule layer focused on type semantics and sequence integrity, with binding state handled elsewhere.

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -45,7 +45,7 @@ If any invariant fails, construction throws `IllegalArgumentException`.
 
 Text parsing supports one or two lines:
 
-- one line: parses forward and auto-generates reverse complement
+- one line: parses forward and auto-generates the complementary reverse strand
 - two lines: parses both and validates complementarity
 
 `toString()` serializes DNA as two lines (`forward` then `reverse`).

--- a/docs/biology/primitives.md
+++ b/docs/biology/primitives.md
@@ -129,7 +129,7 @@ Half-open ranges are used throughout interaction code to make slicing and overla
 ## Example workflow
 
 1. Parse a sequence: `NucleotideSequence.parse(">AUGCUA>")`
-2. Select a region: `slice(SequenceRange(1, 4))` → `UGC`
+2. Select a region: `slice(SequenceRange(1, 4))` → `>UGC>`
 3. Compute complement for pairing logic
 4. Use `SequenceRange` values as coordinates in binding models
 

--- a/docs/biology/primitives.md
+++ b/docs/biology/primitives.md
@@ -88,7 +88,7 @@ Direction is part of sequence identity in this model.
 - explicit forward: `>AUGC>`
 - explicit backward: `<AUGC<`
 
-Markers must be paired and matching. Invalid markers or symbols raise `IllegalArgumentException` with index-aware error messages.
+Markers must be paired and matching. Invalid markers and invalid symbols both raise `IllegalArgumentException`; invalid nucleotide symbols use index-aware error messages, while marker-related errors are reported against the full input string.
 
 `toString()` emits marker-wrapped text, e.g. `>AUGC>`.
 

--- a/docs/biology/primitives.md
+++ b/docs/biology/primitives.md
@@ -1,0 +1,136 @@
+# Primitives
+
+This document describes the biology-layer primitives in `life.sim.biology.primitives`.
+
+These types form the low-level sequence model used by higher-level molecule and interaction APIs.
+
+---
+
+## Design goals
+
+The primitive layer is intentionally small and predictable:
+
+- represent nucleotides compactly and consistently
+- keep sequence data immutable
+- make directionality explicit
+- use clear index/range semantics for slicing and binding
+
+---
+
+## `Nucleotide`
+
+`Nucleotide` is an enum with four RNA-style symbols:
+
+- `A`
+- `C`
+- `G`
+- `U`
+
+Each value stores:
+
+- a compact 2-bit encoding (`bits`)
+- a printable symbol (`symbol`)
+
+Current bit mapping:
+
+- `A = 0b00`
+- `C = 0b01`
+- `G = 0b10`
+- `U = 0b11`
+
+Complement rules are RNA-style:
+
+- `A <-> U`
+- `C <-> G`
+
+Construction helpers:
+
+- `Nucleotide.fromChar(symbol)`
+- `Nucleotide.fromBits(bits: Byte)`
+- `Nucleotide.fromBits(bits: Int)`
+
+All constructors validate input and throw `IllegalArgumentException` on invalid values.
+
+---
+
+## `SequenceDirection`
+
+`SequenceDirection` models orientation:
+
+- `FORWARD` (marker `>`)
+- `BACKWARD` (marker `<`)
+
+It also provides `opposite()` to flip orientation.
+
+Direction is part of sequence identity in this model.
+
+---
+
+## `NucleotideSequence`
+
+`NucleotideSequence` is an immutable wrapper around a list of `Nucleotide` values plus a `SequenceDirection`.
+
+### Core API
+
+- random access: `get(index)`
+- iteration: `Iterable<Nucleotide>`
+- `size`, `isEmpty()`
+- slicing: `slice(range)` or `slice(start, endExclusive)`
+- transforms:
+  - `complement()` (base-complement + opposite direction)
+  - `reversed()` (reverse order + opposite direction)
+
+### Parsing and text format
+
+`NucleotideSequence.parse(text)` supports:
+
+- bare text (defaults to forward): `AUGC`
+- explicit forward: `>AUGC>`
+- explicit backward: `<AUGC<`
+
+Markers must be paired and matching. Invalid markers or symbols raise `IllegalArgumentException` with index-aware error messages.
+
+`toString()` emits marker-wrapped text, e.g. `>AUGC>`.
+
+### Construction helpers
+
+- `empty(direction = FORWARD)`
+- `of(vararg nucleotides, direction = FORWARD)`
+- `of(text)` / `parse(text)`
+- `from(list, direction = FORWARD)`
+- extension: `List<Nucleotide>.toNucleotideSequence()`
+
+---
+
+## `SequenceRange`
+
+`SequenceRange(start, endExclusive)` defines a half-open range over sequence indexes:
+
+- `start` is inclusive
+- `endExclusive` is exclusive
+
+Examples:
+
+- `SequenceRange(2, 5)` covers indexes `2`, `3`, `4`
+- `length = endExclusive - start`
+
+Validation and behavior:
+
+- `start >= 0`
+- `endExclusive >= start`
+- empty ranges are allowed
+- `contains(index)` checks membership
+- `overlaps(other)` uses strict overlap semantics
+
+Half-open ranges are used throughout interaction code to make slicing and overlap checks straightforward.
+
+---
+
+## Example workflow
+
+1. Parse a sequence: `NucleotideSequence.parse(">AUGCUA>")`
+2. Select a region: `slice(SequenceRange(1, 4))` → `UGC`
+3. Compute complement for pairing logic
+4. Use `SequenceRange` values as coordinates in binding models
+
+This keeps sequence-level operations deterministic and independent of simulator/runtime state.


### PR DESCRIPTION
### Motivation
- Provide a clear reference for the biology-layer types and their intended invariants, parsing, and APIs to aid development and design discussions.
- Surface the current set of biology documents in the top-level docs `README` so contributors can find `primitives` and `molecules` docs easily.

### Description
- Update `docs/README.md` to list the current biology docs and recommend the documentation structure.
- Add `docs/biology/primitives.md` documenting `Nucleotide`, `SequenceDirection`, `NucleotideSequence`, and `SequenceRange` with parsing, encoding, and API semantics.
- Add `docs/biology/molecules.md` documenting `Dna`, `MRna`, and `TRna` types, their constructors, invariants, parsing/serialization rules, and relationship to the interactions layer.

### Testing
- Documentation-only change; no automated tests were added or modified and no test runs were required for these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde053f5ec83298e88e731db87c595)