### PR TITLE
Refactor bonds into symmetric molecule associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ simple, composable units.
   The simulation aims to push toward a lower-level model where:
 
     * Small building blocks ("base-units") define behavior
-    * Binding, matching, and catalysis emerge from interactions
+    * Binding, matching, and catalysis emerge from molecule-to-molecule associations
     * Complex machinery (like ribosomes) can evolve rather than be predefined
+    * Temporary complexes can form as dynamic networks of bonded molecules
 
 * **Evolvable neural and behavioral systems**
   Organisms can form internal signaling and neural-like structures,
@@ -104,6 +105,7 @@ life-sim/
 
     * `life.sim.biology.primitives` for sequence building blocks like `Nucleotide`, `NucleotideSequence`, and `SequenceDirection`
     * `life.sim.biology.molecules` for molecule types like `Dna`, `MRna`, and `TRna`
+    * `life.sim.biology.interactions` for runtime molecule associations and bond-network behavior
 
 * Genetics-oriented representations and future mutation logic
 * Binding and matching rules

--- a/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
@@ -1,11 +1,38 @@
 package life.sim.biology.interactions
 
 /**
- * Runtime record of an agent bound to a site on a molecule.
+ * One endpoint of a runtime molecule association.
+ */
+sealed interface BondEndpoint {
+    val moleculeId: MoleculeId
+    val site: BindingSite?
+}
+
+/**
+ * Endpoint that references only a whole molecule instance.
+ */
+data class WholeMoleculeEndpoint(
+    override val moleculeId: MoleculeId,
+) : BondEndpoint {
+    override val site: BindingSite? = null
+}
+
+/**
+ * Endpoint that references a specific binding site on a molecule.
+ */
+data class SiteEndpoint(
+    override val site: BindingSite,
+) : BondEndpoint {
+    override val moleculeId: MoleculeId
+        get() = site.moleculeId
+}
+
+/**
+ * Runtime association between two molecule endpoints.
  */
 data class Bond(
-    val site: BindingSite,
-    val agent: BoundAgent,
+    val left: BondEndpoint,
+    val right: BondEndpoint,
     val strength: Double,
     val decayPerTick: Double,
 ) {
@@ -20,6 +47,12 @@ data class Bond(
 
     fun isActive(): Boolean = strength > 0.0
 
+    fun involves(moleculeId: MoleculeId): Boolean =
+        left.moleculeId == moleculeId || right.moleculeId == moleculeId
+
+    fun siteEndpoints(): List<BindingSite> =
+        listOfNotNull(left.site, right.site)
+
     fun decay(ticks: Int = 1): Bond {
         require(ticks >= 0) {
             "Bond decay ticks must be greater than or equal to zero, but was $ticks."
@@ -28,4 +61,3 @@ data class Bond(
         return copy(strength = (strength - (decayPerTick * ticks)).coerceAtLeast(0.0))
     }
 }
-

--- a/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
@@ -50,7 +50,7 @@ data class Bond(
     fun involves(moleculeId: MoleculeId): Boolean =
         left.moleculeId == moleculeId || right.moleculeId == moleculeId
 
-    fun siteEndpoints(): List<BindingSite> =
+    fun bindingSites(): List<BindingSite> =
         listOfNotNull(left.site, right.site)
 
     fun decay(ticks: Int = 1): Bond {

--- a/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
@@ -28,11 +28,16 @@ class BondRegistry(
 
     fun toList(): List<Bond> = bonds.toList()
 
-    fun bondsFor(moleculeId: MoleculeId): List<Bond> = bonds.filter { it.site.moleculeId == moleculeId }
+    fun bondsFor(moleculeId: MoleculeId): List<Bond> = bonds.filter { it.involves(moleculeId) }
 
-    fun bondsOnSurface(site: BindingSite): List<Bond> = bonds.filter { it.site.sameSurfaceAs(site) }
+    fun bondsInvolving(site: BindingSite): List<Bond> =
+        bonds.filter { bond -> bond.siteEndpoints().any { it == site } }
 
-    fun overlapping(site: BindingSite): List<Bond> = bonds.filter { it.site.overlaps(site) }
+    fun bondsOnSurface(site: BindingSite): List<Bond> =
+        bonds.filter { bond -> bond.siteEndpoints().any { it.sameSurfaceAs(site) } }
+
+    fun overlapping(site: BindingSite): List<Bond> =
+        bonds.filter { bond -> bond.siteEndpoints().any { it.overlaps(site) } }
 
     fun decayAll(ticks: Int = 1): List<Bond> {
         require(ticks >= 0) {
@@ -50,4 +55,3 @@ class BondRegistry(
 
     override fun iterator(): Iterator<Bond> = bonds.toList().iterator()
 }
-

--- a/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
@@ -31,13 +31,13 @@ class BondRegistry(
     fun bondsFor(moleculeId: MoleculeId): List<Bond> = bonds.filter { it.involves(moleculeId) }
 
     fun bondsInvolving(site: BindingSite): List<Bond> =
-        bonds.filter { bond -> bond.siteEndpoints().any { it == site } }
+        bonds.filter { bond -> bond.bindingSites().any { it == site } }
 
     fun bondsOnSurface(site: BindingSite): List<Bond> =
-        bonds.filter { bond -> bond.siteEndpoints().any { it.sameSurfaceAs(site) } }
+        bonds.filter { bond -> bond.bindingSites().any { it.sameSurfaceAs(site) } }
 
     fun overlapping(site: BindingSite): List<Bond> =
-        bonds.filter { bond -> bond.siteEndpoints().any { it.overlaps(site) } }
+        bonds.filter { bond -> bond.bindingSites().any { it.overlaps(site) } }
 
     fun decayAll(ticks: Int = 1): List<Bond> {
         require(ticks >= 0) {

--- a/biology/src/main/kotlin/life/sim/biology/interactions/BoundAgent.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BoundAgent.kt
@@ -1,7 +1,0 @@
-package life.sim.biology.interactions
-
-/**
- * Marker interface for runtime entities that can be bonded to a molecule site.
- */
-interface BoundAgent
-

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
@@ -9,36 +9,103 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class BondRegistryTest {
-    private data class TestAgent(
-        val label: String,
-    ) : BoundAgent
-
     @Test
-    fun `registry stores bonds and queries them by molecule and overlap`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(11))
-        val first = Bond(surface.site(1, 4), TestAgent("repressor"), strength = 0.8, decayPerTick = 0.1)
-        val second = Bond(surface.site(4, 6), TestAgent("polymerase"), strength = 0.9, decayPerTick = 0.2)
-        val registry = BondRegistry(listOf(first, second))
+    fun `registry supports site to site, site to whole, and whole to whole bonds`() {
+        val firstSurface = MRna.of("AUGCUA").bindingSurface(MoleculeId(11))
+        val secondSurface = MRna.of("CGAAUU").bindingSurface(MoleculeId(12))
 
-        assertEquals(listOf(first, second), registry.bondsFor(MoleculeId(11)))
-        assertEquals(listOf(first), registry.overlapping(surface.site(2, 4)))
-        assertEquals(listOf(first, second), registry.bondsOnSurface(surface.site(0, 1)))
+        val siteToSite = Bond(
+            left = SiteEndpoint(firstSurface.site(1, 4)),
+            right = SiteEndpoint(secondSurface.site(0, 3)),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
+        val siteToWhole = Bond(
+            left = SiteEndpoint(firstSurface.site(4, 6)),
+            right = WholeMoleculeEndpoint(MoleculeId(13)),
+            strength = 0.9,
+            decayPerTick = 0.2,
+        )
+        val wholeToWhole = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(13)),
+            right = WholeMoleculeEndpoint(MoleculeId(14)),
+            strength = 0.7,
+            decayPerTick = 0.05,
+        )
+
+        val registry = BondRegistry(listOf(siteToSite, siteToWhole, wholeToWhole))
+
+        assertEquals(listOf(siteToSite, siteToWhole), registry.bondsFor(MoleculeId(11)))
+        assertEquals(listOf(siteToWhole, wholeToWhole), registry.bondsFor(MoleculeId(13)))
+        assertEquals(listOf(wholeToWhole), registry.bondsFor(MoleculeId(14)))
     }
 
     @Test
-    fun `registry overlap queries ignore empty sites`() {
+    fun `registry overlap queries only consider site-aware endpoints`() {
         val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(17))
-        val bond = Bond(surface.site(4, 6), TestAgent("polymerase"), strength = 0.9, decayPerTick = 0.2)
-        val registry = BondRegistry(listOf(bond))
+        val siteToWhole = Bond(
+            left = SiteEndpoint(surface.site(1, 4)),
+            right = WholeMoleculeEndpoint(MoleculeId(21)),
+            strength = 0.9,
+            decayPerTick = 0.2,
+        )
+        val wholeToWhole = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(21)),
+            right = WholeMoleculeEndpoint(MoleculeId(22)),
+            strength = 0.9,
+            decayPerTick = 0.2,
+        )
+        val registry = BondRegistry(listOf(siteToWhole, wholeToWhole))
 
+        assertEquals(listOf(siteToWhole), registry.overlapping(surface.site(2, 3)))
         assertTrue(registry.overlapping(surface.site(5, 5)).isEmpty())
+        assertTrue(registry.overlapping(MRna.of("CC").bindingSurface(MoleculeId(22)).site(0, 2)).isEmpty())
+    }
+
+    @Test
+    fun `registry can query bonds by exact site and by surface`() {
+        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(15))
+        val exactSite = surface.site(1, 4)
+        val otherSite = surface.site(4, 6)
+        val first = Bond(
+            left = SiteEndpoint(exactSite),
+            right = WholeMoleculeEndpoint(MoleculeId(99)),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
+        val second = Bond(
+            left = SiteEndpoint(otherSite),
+            right = WholeMoleculeEndpoint(MoleculeId(100)),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
+        val wholeOnly = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(15)),
+            right = WholeMoleculeEndpoint(MoleculeId(101)),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
+        val registry = BondRegistry(listOf(first, second, wholeOnly))
+
+        assertEquals(listOf(first), registry.bondsInvolving(exactSite))
+        assertEquals(listOf(first, second), registry.bondsOnSurface(surface.site(0, 1)))
     }
 
     @Test
     fun `registry ignores inactive bonds supplied at construction`() {
         val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(15))
-        val active = Bond(surface.site(1, 4), TestAgent("active"), strength = 0.8, decayPerTick = 0.1)
-        val inactive = Bond(surface.site(4, 6), TestAgent("inactive"), strength = 0.0, decayPerTick = 0.2)
+        val active = Bond(
+            left = SiteEndpoint(surface.site(1, 4)),
+            right = WholeMoleculeEndpoint(MoleculeId(31)),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
+        val inactive = Bond(
+            left = SiteEndpoint(surface.site(4, 6)),
+            right = WholeMoleculeEndpoint(MoleculeId(32)),
+            strength = 0.0,
+            decayPerTick = 0.2,
+        )
 
         val registry = BondRegistry(listOf(active, inactive))
 
@@ -51,7 +118,12 @@ class BondRegistryTest {
     @Test
     fun `registry add ignores inactive bonds`() {
         val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(16))
-        val inactive = Bond(surface.site(1, 4), TestAgent("inactive"), strength = 0.0, decayPerTick = 0.1)
+        val inactive = Bond(
+            left = SiteEndpoint(surface.site(1, 4)),
+            right = WholeMoleculeEndpoint(MoleculeId(90)),
+            strength = 0.0,
+            decayPerTick = 0.1,
+        )
         val registry = BondRegistry()
 
         val returned = registry.add(inactive)
@@ -66,8 +138,18 @@ class BondRegistryTest {
     @Test
     fun `registry decay removes inactive bonds and keeps surviving strength`() {
         val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(12))
-        val transient = Bond(surface.site(0, 2), TestAgent("weak"), strength = 0.1, decayPerTick = 0.1)
-        val stable = Bond(surface.site(2, 5), TestAgent("stable"), strength = 0.9, decayPerTick = 0.2)
+        val transient = Bond(
+            left = SiteEndpoint(surface.site(0, 2)),
+            right = WholeMoleculeEndpoint(MoleculeId(41)),
+            strength = 0.1,
+            decayPerTick = 0.1,
+        )
+        val stable = Bond(
+            left = SiteEndpoint(surface.site(2, 5)),
+            right = WholeMoleculeEndpoint(MoleculeId(42)),
+            strength = 0.9,
+            decayPerTick = 0.2,
+        )
         val registry = BondRegistry(listOf(transient, stable))
 
         val remaining = registry.decayAll(2)
@@ -79,7 +161,12 @@ class BondRegistryTest {
 
     @Test
     fun `bond decay rejects negative tick counts`() {
-        val bond = Bond(MRna.of("AUG").bindingSurface(MoleculeId(13)).site(0, 2), TestAgent("repressor"), 1.0, 0.1)
+        val bond = Bond(
+            left = SiteEndpoint(MRna.of("AUG").bindingSurface(MoleculeId(13)).site(0, 2)),
+            right = WholeMoleculeEndpoint(MoleculeId(50)),
+            strength = 1.0,
+            decayPerTick = 0.1,
+        )
 
         val exception = assertFailsWith<IllegalArgumentException> {
             bond.decay(-1)
@@ -90,10 +177,14 @@ class BondRegistryTest {
 
     @Test
     fun `bond reports whether it is still active`() {
-        val bond = Bond(MRna.of("AUG").bindingSurface(MoleculeId(14)).site(0, 2), TestAgent("repressor"), 0.0, 0.1)
+        val bond = Bond(
+            left = SiteEndpoint(MRna.of("AUG").bindingSurface(MoleculeId(14)).site(0, 2)),
+            right = WholeMoleculeEndpoint(MoleculeId(51)),
+            strength = 0.0,
+            decayPerTick = 0.1,
+        )
 
         assertFalse(bond.isActive())
         assertTrue(bond.copy(strength = 0.01).isActive())
     }
 }
-

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
@@ -67,6 +67,7 @@ class BondRegistryTest {
         val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(15))
         val exactSite = surface.site(1, 4)
         val otherSite = surface.site(4, 6)
+        val rightOnlySite = surface.site(0, 2)
         val first = Bond(
             left = SiteEndpoint(exactSite),
             right = WholeMoleculeEndpoint(MoleculeId(99)),
@@ -79,16 +80,24 @@ class BondRegistryTest {
             strength = 0.8,
             decayPerTick = 0.1,
         )
+        val siteOnRight = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(102)),
+            right = SiteEndpoint(rightOnlySite),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
         val wholeOnly = Bond(
             left = WholeMoleculeEndpoint(MoleculeId(15)),
             right = WholeMoleculeEndpoint(MoleculeId(101)),
             strength = 0.8,
             decayPerTick = 0.1,
         )
-        val registry = BondRegistry(listOf(first, second, wholeOnly))
+        val registry = BondRegistry(listOf(first, second, siteOnRight, wholeOnly))
 
         assertEquals(listOf(first), registry.bondsInvolving(exactSite))
-        assertEquals(listOf(first, second), registry.bondsOnSurface(surface.site(0, 1)))
+        assertEquals(listOf(siteOnRight), registry.bondsInvolving(rightOnlySite))
+        assertEquals(listOf(first, second, siteOnRight), registry.bondsOnSurface(surface.site(0, 1)))
+        assertEquals(listOf(siteOnRight), registry.overlapping(surface.site(0, 1)))
     }
 
     @Test

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -2,36 +2,36 @@
 
 This document explains the current bond model in `life.sim.biology.interactions`.
 
-The goal of the bond layer is to represent **runtime occupancy** on molecules such as DNA and RNA without putting mutable state directly into immutable value types like:
+The bond layer models **runtime associations between molecules** without putting mutable state directly into immutable molecule value types such as:
 
 - `life.sim.biology.primitives.NucleotideSequence`
 - `life.sim.biology.molecules.Dna`
 - `life.sim.biology.molecules.MRna`
 - `life.sim.biology.molecules.TRna`
 
-In other words:
+In short:
 
-- molecule classes describe **what a molecule is**
-- bond classes describe **what is currently bound to it**
+- molecule classes describe **what molecules are**
+- bond classes describe **which molecules are currently associated**
+
+Associations can be site-specific, molecule-wide, or mixed.
 
 ---
 
 ## Why bonds are separate from molecules
 
-A DNA or mRNA sequence should still be the same molecule value whether:
+A DNA or RNA molecule value should still be the same value whether:
 
-- nothing is bound to it
-- a repressor is bound over a regulatory site
-- a polymerase is bound near a start region
-- several weak bonds are present and decaying over time
+- nothing is currently associated with it
+- one site is occupied by another molecule
+- several molecules are connected as a temporary complex
+- some associations are coarse-grained (whole-molecule) and others are site-level
 
-Because of that, bond state lives in the `interactions` package as runtime data.
+Because of that, bond state lives in `interactions` as runtime data.
 
 ---
 
 ## Core concepts
-
-The current model is built from a few small pieces.
 
 ## 1. `SequenceRange`
 
@@ -42,13 +42,6 @@ The current model is built from a few small pieces.
 
 So a range like `SequenceRange(2, 5)` covers indexes `2`, `3`, and `4`.
 
-This makes slicing and overlap checks easier and less error-prone.
-
-### Example
-
-- `SequenceRange(1, 4)` on `>AUGCUA>` refers to `UGC`
-- `SequenceRange(4, 6)` refers to `UA`
-
 ---
 
 ## 2. `BindingSurface`
@@ -57,17 +50,9 @@ A `BindingSurface` is an addressable strand of a molecule.
 
 It contains:
 
-- `moleculeId`: a stable runtime identity for the molecule instance
-- `strand`: which strand is being addressed
-- `sequence`: the sequence exposed by that strand
-
-Current strand options are:
-
-- `BindingStrand.SINGLE`
-- `BindingStrand.FORWARD`
-- `BindingStrand.REVERSE`
-
-This means DNA and RNA can share one site model.
+- `moleculeId`: stable runtime identity
+- `strand`: strand selection (`SINGLE`, `FORWARD`, `REVERSE`)
+- `sequence`: exposed sequence on that strand
 
 ---
 
@@ -82,63 +67,51 @@ This gives a concrete address like:
 
 - molecule `11`
 - forward strand
-- indexes `[12, 20)` (that is, indexes `12` through `19`)
-
-A `BindingSite` can also expose the exact subsequence at that site via `site.sequence`.
+- indexes `[12, 20)`
 
 ---
 
-## 4. `Bond`
+## 4. `BondEndpoint`
 
-A `Bond` is the actual runtime record of something bound to a site.
+A `BondEndpoint` names one side of a bond. Two endpoint variants are supported:
 
-It stores:
+- `SiteEndpoint(site)` for site-aware associations
+- `WholeMoleculeEndpoint(moleculeId)` for non-site-specific associations
 
-- `site`: where the bond exists
-- `agent`: what is bound there
-- `strength`: current bond strength
-- `decayPerTick`: how much strength is lost per decay step
+This allows:
 
-This is the current data shape behind bond state.
-
----
-
-## 5. `BondRegistry`
-
-`BondRegistry` is a mutable in-memory store of active bonds.
-
-It currently supports:
-
-- adding and removing bonds
-- listing bonds for a molecule
-- listing bonds on the same surface
-- finding overlapping bonds
-- decaying all bonds and removing inactive ones
-
-Right now, this is intentionally simple: it is a runtime storage object, not yet a full simulation system.
+- site ↔ site
+- site ↔ whole molecule
+- whole molecule ↔ whole molecule
 
 ---
 
-## Molecule surfaces
+## 5. `Bond`
 
-The extension helpers in `MoleculeBindingSites.kt` expose molecule-specific binding surfaces.
+`Bond` is a runtime association between two molecule endpoints:
 
-## DNA
+- `left: BondEndpoint`
+- `right: BondEndpoint`
+- `strength`
+- `decayPerTick`
 
-DNA has two separate addressable surfaces:
+It keeps lifecycle helpers:
 
-- `forwardBindingSurface(id)`
-- `reverseBindingSurface(id)`
+- `isActive()`
+- `decay(ticks)`
 
-That lets you distinguish between strand-specific sites on the duplex.
+---
 
-## mRNA and tRNA
+## 6. `BondRegistry`
 
-RNA molecules currently expose a single strand:
+`BondRegistry` stores active bonds and supports:
 
-- `bindingSurface(id)`
-
-This maps to `BindingStrand.SINGLE`.
+- add/remove
+- query by participating molecule (`bondsFor`)
+- query bonds touching an exact site (`bondsInvolving`)
+- query bonds that have any endpoint on the same surface (`bondsOnSurface`)
+- query overlap against a site (`overlapping`)
+- decay all bonds and remove inactive entries (`decayAll`)
 
 ---
 
@@ -184,13 +157,23 @@ classDiagram
         +overlaps(other)
     }
 
-    class BoundAgent {
+    class BondEndpoint {
         <<interface>>
+        +MoleculeId moleculeId
+        +BindingSite? site
+    }
+
+    class SiteEndpoint {
+        +BindingSite site
+    }
+
+    class WholeMoleculeEndpoint {
+        +MoleculeId moleculeId
     }
 
     class Bond {
-        +BindingSite site
-        +BoundAgent agent
+        +BondEndpoint left
+        +BondEndpoint right
         +Double strength
         +Double decayPerTick
         +isActive()
@@ -202,209 +185,138 @@ classDiagram
         +add(bond)
         +remove(bond)
         +bondsFor(moleculeId)
+        +bondsInvolving(site)
         +bondsOnSurface(site)
         +overlapping(site)
         +decayAll(ticks)
     }
 
+    BondEndpoint <|.. SiteEndpoint
+    BondEndpoint <|.. WholeMoleculeEndpoint
     BindingSurface --> MoleculeId
     BindingSurface --> BindingStrand
     BindingSite --> BindingSurface
     BindingSite --> SequenceRange
-    Bond --> BindingSite
-    Bond --> BoundAgent
+    SiteEndpoint --> BindingSite
+    Bond --> BondEndpoint
     BondRegistry --> Bond
 ```
 
 ---
 
-## How complementary matching works
-
-`BindingMatcher` provides shared sequence-driven matching logic.
-
-The main function is:
-
-- `complementaryMatchStart(pattern, target)`
-
-It scans the target and returns:
-
-- the first start index where the pattern matches by complementarity
-- `-1` if no complementary match exists
-
-There is also:
-
-- `complementaryMatchSite(pattern, surface)`
-
-which returns a full `BindingSite` when a complementary match is found.
-
-This logic is now shared with `TRna.scan(...)`, so tRNA scanning and general complementary binding use the same rules.
-
----
-
 ## Matching flow
+
+`BindingMatcher` still handles complementary sequence matching and site generation.
 
 ```mermaid
 flowchart LR
-    A[Pattern sequence<br/>e.g. tRNA or binding motif] --> B[BindingMatcher]
+    A[Pattern sequence] --> B[BindingMatcher]
     B --> C{Complementary match found?}
     C -- No --> D[Return -1 or null]
     C -- Yes --> E[Create SequenceRange]
     E --> F[Create BindingSite on target surface]
-    F --> G[Optional: create Bond]
+    F --> G[Create SiteEndpoint or mixed Bond]
     G --> H[Store in BondRegistry]
 ```
 
 ---
 
-## Example: finding a site on mRNA
-
-Suppose we have:
-
-- pattern: `AUG`
-- target mRNA sequence: `CCUACUAC`
-
-The complementary match is found at index `2`, because:
-
-- pattern: `A U G`
-- target site: `U A C`
-- each position complements the pattern
-
-So the resulting site is:
-
-- `SequenceRange(2, 5)`
-- strand: `SINGLE`
-- sequence: `UAC`
-
----
-
-## Example: creating a bond
-
-A repressor-like agent could bind to a previously identified site.
-
-Conceptually:
-
-1. identify a molecule surface
-2. identify or compute a binding site
-3. create a bond with strength and decay
-4. store it in a registry
+## Example: creating different bond kinds
 
 ```kotlin
-val surface = mrna.bindingSurface(MoleculeId(11))
-val site = surface.site(2, 5)
-val bond = Bond(
-    site = site,
-    agent = repressor,
-    strength = 0.8,
-    decayPerTick = 0.1,
-)
-registry.add(bond)
-```
+val dnaSurface = dna.forwardBindingSurface(MoleculeId(11))
+val rnaSurface = mrna.bindingSurface(MoleculeId(12))
 
-The exact `repressor` type is not implemented yet, but it would implement `BoundAgent`.
+val siteToSite = Bond(
+    left = SiteEndpoint(dnaSurface.site(3, 8)),
+    right = SiteEndpoint(rnaSurface.site(0, 5)),
+    strength = 0.8,
+    decayPerTick = 0.05,
+)
+
+val siteToWhole = Bond(
+    left = SiteEndpoint(dnaSurface.site(8, 12)),
+    right = WholeMoleculeEndpoint(MoleculeId(99)),
+    strength = 0.7,
+    decayPerTick = 0.08,
+)
+
+val wholeToWhole = Bond(
+    left = WholeMoleculeEndpoint(MoleculeId(99)),
+    right = WholeMoleculeEndpoint(MoleculeId(100)),
+    strength = 0.6,
+    decayPerTick = 0.03,
+)
+
+registry.add(siteToSite)
+registry.add(siteToWhole)
+registry.add(wholeToWhole)
+```
 
 ---
 
-## Overlap and occupancy
+## Overlap semantics
 
-Two sites overlap only when all of the following are true:
-
-1. they are on the same molecule
-2. they are on the same strand/surface
-3. their ranges overlap
+Overlap is defined only for endpoints that have `BindingSite` detail.
 
 That means:
 
-- two sites on different molecules do **not** overlap
-- forward and reverse DNA strand sites do **not** overlap
-- adjacent half-open ranges like `[1, 4)` and `[4, 6)` do **not** overlap
+- site ↔ site overlap works as usual
+- site ↔ whole molecule does **not** produce overlap from the whole endpoint
+- whole ↔ whole has no site range and is ignored by overlap queries
+- surface queries (`bondsOnSurface`) ignore whole-molecule endpoints
 
-This is important for repression, blocking, or collision logic later.
-
-### Overlap example
-
-```mermaid
-sequenceDiagram
-    participant Surface as BindingSurface(molecule 11, SINGLE)
-    participant SiteA as Site A [1,4)
-    participant SiteB as Site B [2,4)
-    participant Registry as BondRegistry
-
-    Surface->>SiteA: create site
-    Surface->>SiteB: create query site
-    Registry->>Registry: overlapping(SiteB)
-    Registry-->>SiteB: returns bonds whose sites overlap [2,4)
-```
+This keeps DNA/RNA occupancy checks precise while allowing coarse associations elsewhere.
 
 ---
 
 ## Bond decay
 
-A bond weakens over time using:
-
-- `strength`
-- `decayPerTick`
-
-Calling `bond.decay(ticks)` reduces strength linearly:
+Decay remains unchanged:
 
 - new strength = `max(0.0, strength - decayPerTick * ticks)`
-
-`BondRegistry.decayAll(ticks)` applies this to every stored bond and removes bonds that are no longer active.
-
-This gives a simple first-pass lifecycle for temporary occupancy.
+- inactive bonds are removed by `BondRegistry.decayAll(ticks)`
 
 ---
 
 ## What this model is good at
 
-The current design is well suited for:
+The current model supports both occupancy and connectivity:
 
-- repressors bound to DNA sites
-- polymerases bound to strand-specific start regions
-- temporary occupancy on mRNA
-- overlap checks for blocked regions
-- simple time-based decay of bonds
+- DNA/RNA site occupancy with overlap checks
+- mixed-detail associations while models are still coarse
+- temporary complex-internal links as molecule graphs
+- time-based weakening/removal of associations
 
 ---
 
 ## Current limits
 
-This is a deliberately minimal first pass.
-
 Current limitations include:
 
-- `BoundAgent` is only a marker interface
-- `BondRegistry` is in-memory and local, not yet integrated into a wider simulation state model
-- bonds currently connect an agent to one site, not one site to another site
-- there is no conflict resolution or affinity scoring beyond stored strength/decay values
-- there is no built-in concept of promoter, operator, gene, or repression policy yet
+- no built-in conflict resolution beyond explicit query/filter logic
+- no affinity-scoring or competitive binding policy yet
+- registry is still in-memory and not yet integrated with broader simulation state
+- complex membership derivation is not yet packaged as a dedicated helper API
 
 ---
 
 ## Likely next steps
 
-Reasonable follow-up additions would be:
+Reasonable follow-up additions:
 
-- concrete `BoundAgent` implementations such as `Repressor` or `Polymerase`
-- helper logic such as `isBlocked(site)` or `tryBind(agent, site)`
-- gene/operator/promoter annotations that can be checked against active bonds
-- richer affinity models that derive initial bond strength from sequence matching
-- simulator or cell-state integration using `MoleculeId`
+- helpers to derive connected molecule complexes from active bonds
+- higher-level bind/release policies (competition, affinity, blockage)
+- richer interaction semantics for transcription machinery built on top of this substrate
+- optional docs for complex graph behavior (`docs/biology/interactions/complexes.md`)
 
 ---
 
 ## Summary
 
-The current bond system separates:
+The bond system now separates:
 
 - **molecule structure** (`Dna`, `MRna`, `TRna`, `NucleotideSequence`)
-- **runtime binding state** (`BindingSite`, `Bond`, `BondRegistry`)
+- **runtime association state** (`BondEndpoint`, `Bond`, `BondRegistry`)
 
-That gives a clean foundation for later features like:
-
-- gene repression
-- polymerase occupancy
-- blocking/competition between agents
-- time-based bond decay
-
-without turning core molecule types into mutable state containers.
-
+By making bonds symmetric between two molecule participants with optional site detail on either side, the model supports both classical occupancy and emergent complex networks.


### PR DESCRIPTION
### Motivation
- Replace the asymmetric `site + agent` bond model with a symmetric, two-ended association so bonds can represent molecule↔molecule, site↔site, and site↔whole-molecule relationships.
- Support dynamic complexes and graph-like connectivity between molecules while preserving site-aware overlap semantics for DNA/RNA occupancy.
- Remove the privileged `BoundAgent` concept in favor of endpoint-based bonds so either side may optionally include `BindingSite` detail.

### Description
- Introduced a sealed `BondEndpoint` model with `SiteEndpoint` and `WholeMoleculeEndpoint`, and refactored `Bond` to hold `left`/`right` endpoints while preserving `strength`, `decayPerTick`, `isActive()`, and `decay(...)` behavior (`biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt`).
- Updated `BondRegistry` to query by molecule participation and site-aware filters (`bondsFor`, `bondsInvolving`, `bondsOnSurface`, `overlapping`) and retained `decayAll` semantics (`biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt`).
- Removed the `BoundAgent` marker interface and updated tests and docs to the new API, including `BondRegistryTest` changes to cover site↔site, site↔whole, whole↔whole bonds and overlap semantics (`biology/src/test/.../BondRegistryTest.kt`).
- Rewrote `docs/biology/interactions/bonds.md` and updated `README.md` to document the new endpoint-based model, overlap semantics, examples, and intended next steps.

### Testing
- Ran `./gradlew test` initially and encountered an executable permission limitation in this environment (permission denied), which prevented that invocation from running.
- Ran `bash ./gradlew test` to execute the Gradle build and unit tests; iterated to fix a failing assertion in `BondRegistryTest`, and the final `bash ./gradlew test` completed with a successful build and passing unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1ab124648329ae9f5aba707c379e)