### PR TITLE
Make Bond identity undirected and dedupe mirrored registry entries

### DIFF
--- a/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
@@ -60,4 +60,27 @@ data class Bond(
 
         return copy(strength = (strength - (decayPerTick * ticks)).coerceAtLeast(0.0))
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other !is Bond) {
+            return false
+        }
+
+        val endpointsMatch = (left == other.left && right == other.right) ||
+            (left == other.right && right == other.left)
+
+        return endpointsMatch &&
+            strength == other.strength &&
+            decayPerTick == other.decayPerTick
+    }
+
+    override fun hashCode(): Int {
+        var result = left.hashCode() + right.hashCode()
+        result = 31 * result + strength.hashCode()
+        result = 31 * result + decayPerTick.hashCode()
+        return result
+    }
 }

--- a/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
@@ -78,7 +78,15 @@ data class Bond(
     }
 
     override fun hashCode(): Int {
-        var result = left.hashCode() + right.hashCode()
+        val leftHash = left.hashCode()
+        val rightHash = right.hashCode()
+        val (firstEndpointHash, secondEndpointHash) = if (leftHash <= rightHash) {
+            leftHash to rightHash
+        } else {
+            rightHash to leftHash
+        }
+
+        var result = 31 * firstEndpointHash + secondEndpointHash
         result = 31 * result + strength.hashCode()
         result = 31 * result + decayPerTick.hashCode()
         return result

--- a/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
@@ -73,8 +73,8 @@ data class Bond(
             (left == other.right && right == other.left)
 
         return endpointsMatch &&
-            strength == other.strength &&
-            decayPerTick == other.decayPerTick
+            strength.compareTo(other.strength) == 0 &&
+            decayPerTick.compareTo(other.decayPerTick) == 0
     }
 
     override fun hashCode(): Int {

--- a/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
@@ -55,5 +55,5 @@ class BondRegistry(
         return toList()
     }
 
-    override fun iterator(): Iterator<Bond> = bonds.iterator()
+    override fun iterator(): Iterator<Bond> = bonds.toList().iterator()
 }

--- a/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
@@ -6,7 +6,9 @@ package life.sim.biology.interactions
 class BondRegistry(
     initialBonds: Iterable<Bond> = emptyList(),
 ) : Iterable<Bond> {
-    private val bonds = initialBonds.filter(Bond::isActive).toMutableList()
+    private val bonds = initialBonds
+        .filter(Bond::isActive)
+        .toCollection(linkedSetOf())
 
     val size: Int
         get() = bonds.size
@@ -53,5 +55,5 @@ class BondRegistry(
         return toList()
     }
 
-    override fun iterator(): Iterator<Bond> = bonds.toList().iterator()
+    override fun iterator(): Iterator<Bond> = bonds.iterator()
 }

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
@@ -169,6 +169,30 @@ class BondRegistryTest {
     }
 
     @Test
+    fun `registry iterator is a snapshot and is unaffected by later mutations`() {
+        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(24))
+        val first = Bond(
+            left = SiteEndpoint(surface.site(0, 2)),
+            right = WholeMoleculeEndpoint(MoleculeId(25)),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
+        val second = Bond(
+            left = SiteEndpoint(surface.site(2, 4)),
+            right = WholeMoleculeEndpoint(MoleculeId(26)),
+            strength = 0.7,
+            decayPerTick = 0.1,
+        )
+        val registry = BondRegistry(listOf(first))
+
+        val iterator = registry.iterator()
+        registry.add(second)
+
+        assertEquals(listOf(first), iterator.asSequence().toList())
+        assertEquals(listOf(first, second), registry.toList())
+    }
+
+    @Test
     fun `registry decay removes inactive bonds and keeps surviving strength`() {
         val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(12))
         val transient = Bond(

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
@@ -145,6 +145,30 @@ class BondRegistryTest {
     }
 
     @Test
+    fun `registry stores only one active entry for mirrored bonds`() {
+        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(18))
+        val bond = Bond(
+            left = SiteEndpoint(surface.site(1, 4)),
+            right = WholeMoleculeEndpoint(MoleculeId(23)),
+            strength = 0.9,
+            decayPerTick = 0.1,
+        )
+        val mirrored = Bond(
+            left = bond.right,
+            right = bond.left,
+            strength = bond.strength,
+            decayPerTick = bond.decayPerTick,
+        )
+        val registry = BondRegistry()
+
+        registry.add(bond)
+        registry.add(mirrored)
+
+        assertEquals(1, registry.size)
+        assertEquals(listOf(bond), registry.toList())
+    }
+
+    @Test
     fun `registry decay removes inactive bonds and keeps surviving strength`() {
         val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(12))
         val transient = Bond(

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondTest.kt
@@ -103,4 +103,23 @@ class BondTest {
 
         assertNotEquals(first, differentDecay)
     }
+
+    @Test
+    fun `signed zero values are compared consistently with hash code`() {
+        val positiveZeroStrength = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(15)),
+            right = WholeMoleculeEndpoint(MoleculeId(16)),
+            strength = 0.0,
+            decayPerTick = 0.1,
+        )
+        val negativeZeroStrength = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(16)),
+            right = WholeMoleculeEndpoint(MoleculeId(15)),
+            strength = -0.0,
+            decayPerTick = 0.1,
+        )
+
+        assertNotEquals(positiveZeroStrength, negativeZeroStrength)
+        assertNotEquals(positiveZeroStrength.hashCode(), negativeZeroStrength.hashCode())
+    }
 }

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondTest.kt
@@ -1,0 +1,106 @@
+package life.sim.biology.interactions
+
+import life.sim.biology.molecules.MRna
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class BondTest {
+    @Test
+    fun `swapped site to site endpoints compare equal and share hash code`() {
+        val firstSurface = MRna.of("AUGCUA").bindingSurface(MoleculeId(1))
+        val secondSurface = MRna.of("CGAAUU").bindingSurface(MoleculeId(2))
+
+        val first = Bond(
+            left = SiteEndpoint(firstSurface.site(1, 4)),
+            right = SiteEndpoint(secondSurface.site(0, 3)),
+            strength = 0.8,
+            decayPerTick = 0.1,
+        )
+        val mirrored = Bond(
+            left = first.right,
+            right = first.left,
+            strength = first.strength,
+            decayPerTick = first.decayPerTick,
+        )
+
+        assertEquals(first, mirrored)
+        assertEquals(first.hashCode(), mirrored.hashCode())
+    }
+
+    @Test
+    fun `swapped site to whole endpoints compare equal and share hash code`() {
+        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(3))
+        val siteToWhole = Bond(
+            left = SiteEndpoint(surface.site(2, 5)),
+            right = WholeMoleculeEndpoint(MoleculeId(4)),
+            strength = 0.7,
+            decayPerTick = 0.05,
+        )
+        val wholeToSite = Bond(
+            left = siteToWhole.right,
+            right = siteToWhole.left,
+            strength = siteToWhole.strength,
+            decayPerTick = siteToWhole.decayPerTick,
+        )
+
+        assertEquals(siteToWhole, wholeToSite)
+        assertEquals(siteToWhole.hashCode(), wholeToSite.hashCode())
+    }
+
+    @Test
+    fun `swapped whole to whole endpoints compare equal and share hash code`() {
+        val first = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(9)),
+            right = WholeMoleculeEndpoint(MoleculeId(10)),
+            strength = 0.6,
+            decayPerTick = 0.03,
+        )
+        val mirrored = Bond(
+            left = first.right,
+            right = first.left,
+            strength = first.strength,
+            decayPerTick = first.decayPerTick,
+        )
+
+        assertEquals(first, mirrored)
+        assertEquals(first.hashCode(), mirrored.hashCode())
+    }
+
+    @Test
+    fun `different strength still makes mirrored bonds unequal`() {
+        val first = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(11)),
+            right = WholeMoleculeEndpoint(MoleculeId(12)),
+            strength = 0.6,
+            decayPerTick = 0.03,
+        )
+        val differentStrength = Bond(
+            left = first.right,
+            right = first.left,
+            strength = 0.5,
+            decayPerTick = first.decayPerTick,
+        )
+
+        assertNotEquals(first, differentStrength)
+    }
+
+    @Test
+    fun `different decay still makes mirrored bonds unequal`() {
+        val first = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(13)),
+            right = WholeMoleculeEndpoint(MoleculeId(14)),
+            strength = 0.6,
+            decayPerTick = 0.03,
+        )
+        val differentDecay = Bond(
+            left = first.right,
+            right = first.left,
+            strength = first.strength,
+            decayPerTick = 0.04,
+        )
+
+        assertNotEquals(first, differentDecay)
+    }
+}

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -95,6 +95,8 @@ This allows:
 - `strength`
 - `decayPerTick`
 
+Bond identity is **undirected**: swapping `left` and `right` does not create a different bond.
+
 It keeps lifecycle helpers:
 
 - `isActive()`


### PR DESCRIPTION
### Motivation
- Bonds currently used `left`/`right` ordering which made identical undirected associations compare and hash differently, causing confusing duplicates in registries.
- The intent is to treat the existing `Bond` model as an undirected association while keeping `strength` and `decayPerTick` part of identity so future directional semantics can be introduced explicitly.

### Description
- Override `Bond.equals()` to consider `(left,right)` and `(right,left)` equivalent and still compare `strength` and `decayPerTick` for identity, and override `Bond.hashCode()` accordingly (`biology/src/main/kotlin/.../Bond.kt`).
- Change `BondRegistry` storage from a mutable `List` to a `LinkedHashSet` (via `toCollection(linkedSetOf())`) so mirrored bonds are deduplicated while preserving insertion order, and adjust iterator usage (`biology/src/main/kotlin/.../BondRegistry.kt`).
- Add `BondTest` with symmetric equality/hash coverage across site↔site, site↔whole, and whole↔whole bonds and inequality cases for differing `strength` or `decayPerTick` (`biology/src/test/kotlin/.../BondTest.kt`).
- Add a registry test asserting mirrored bonds are stored only once and update docs to state that bond identity is undirected (`biology/src/test/.../BondRegistryTest.kt`, `docs/biology/interactions/bonds.md`).

### Testing
- Ran the module test suite with `./gradlew :biology:test` which completed successfully (BUILD SUCCESSFUL) after the changes.
- The new `BondTest` and updated `BondRegistryTest` executed as part of the run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de837bbd008329aa31180853e19a2d)