### PR TITLE
Bridge SequenceBinder interpretation to runtime BondRegistry binding

### DIFF
--- a/biology/src/main/kotlin/life/sim/biology/proteins/MolecularCapability.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/MolecularCapability.kt
@@ -1,5 +1,8 @@
 package life.sim.biology.proteins
 
+import life.sim.biology.primitives.NucleotideSequence
+
+
 /**
  * Runtime behavior exposed by one interpreted protein domain.
  */
@@ -8,6 +11,7 @@ sealed interface MolecularCapability {
 }
 
 data class SequenceBinder(
+    val bindingPattern: NucleotideSequence,
     val affinity: Double,
     val specificity: Double,
 ) : MolecularCapability {

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -22,10 +22,15 @@ object ProteinBinding {
     ): Bond? {
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target) ?: return null
 
+        val normalizedStrength = binder.affinity.coerceIn(0.0, 1.0)
+        if (normalizedStrength <= 0.0) {
+            return null
+        }
+
         val bond = Bond(
             left = WholeMoleculeEndpoint(proteinId),
             right = SiteEndpoint(targetSite),
-            strength = binder.affinity.coerceIn(0.0, 1.0),
+            strength = normalizedStrength,
             decayPerTick = DEFAULT_DECAY_PER_TICK,
         )
 

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -1,0 +1,35 @@
+package life.sim.biology.proteins
+
+import life.sim.biology.interactions.BindingMatcher
+import life.sim.biology.interactions.BindingSurface
+import life.sim.biology.interactions.Bond
+import life.sim.biology.interactions.BondRegistry
+import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.interactions.SiteEndpoint
+import life.sim.biology.interactions.WholeMoleculeEndpoint
+
+/**
+ * Runtime bridge from interpreted protein capabilities to concrete bonds.
+ */
+object ProteinBinding {
+    private const val DEFAULT_DECAY_PER_TICK = 0.05
+
+    fun tryBind(
+        proteinId: MoleculeId,
+        binder: SequenceBinder,
+        target: BindingSurface,
+        registry: BondRegistry,
+    ): Bond? {
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target) ?: return null
+
+        val bond = Bond(
+            left = WholeMoleculeEndpoint(proteinId),
+            right = SiteEndpoint(targetSite),
+            strength = binder.affinity.coerceIn(0.0, 1.0),
+            decayPerTick = DEFAULT_DECAY_PER_TICK,
+        )
+
+        registry.add(bond)
+        return bond
+    }
+}

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinInterpreter.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinInterpreter.kt
@@ -2,12 +2,15 @@ package life.sim.biology.proteins
 
 import life.sim.biology.molecules.AminoAcid
 import life.sim.biology.molecules.Polypeptide
+import life.sim.biology.primitives.Nucleotide
+import life.sim.biology.primitives.NucleotideSequence
 
 /**
  * Interprets [Polypeptide] chains as composable domains by motif matching.
  */
 object ProteinInterpreter {
     private const val DOMAIN_WINDOW_RADIUS = 2
+    private const val BINDER_PATTERN_LENGTH = 6
 
     private data class DomainPattern(
         val name: String,
@@ -22,6 +25,7 @@ object ProteinInterpreter {
             motif = "KRGK",
             factory = { local ->
                 SequenceBinder(
+                    bindingPattern = deriveBinderPattern(local),
                     affinity = clamp01(0.45 + weightedSignal(local, chargeWeight = 0.08, hydrophobicWeight = 0.02)),
                     specificity = clamp01(0.35 + weightedSignal(local, chargeWeight = 0.04, hydrophobicWeight = 0.05)),
                 )
@@ -124,6 +128,25 @@ object ProteinInterpreter {
     private fun hydrophobicScore(residue: AminoAcid): Double = when (residue) {
         AminoAcid.A, AminoAcid.I, AminoAcid.L, AminoAcid.M, AminoAcid.F, AminoAcid.W, AminoAcid.Y, AminoAcid.V -> 1.0
         else -> 0.0
+    }
+
+    private fun deriveBinderPattern(localWindow: List<AminoAcid>): NucleotideSequence {
+        val seed = localWindow.foldIndexed(17) { index, acc, residue ->
+            (acc * 31) + (residue.symbol.code * (index + 1))
+        }
+
+        var state = seed
+        val pattern = List(BINDER_PATTERN_LENGTH) {
+            state = state * 1103515245 + 12345
+            when ((state ushr 16) and 0x3) {
+                0 -> Nucleotide.A
+                1 -> Nucleotide.C
+                2 -> Nucleotide.G
+                else -> Nucleotide.U
+            }
+        }
+
+        return NucleotideSequence.from(pattern)
     }
 
     private fun clamp01(value: Double): Double = value.coerceIn(0.0, 1.0)

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -53,6 +53,24 @@ class ProteinBindingTest {
         assertTrue(registry.isEmpty())
     }
 
+
+    @Test
+    fun `tryBind returns null when affinity normalizes to inactive bond strength`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.0)
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(32))
+        val registry = BondRegistry()
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(203),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNull(bond)
+        assertTrue(registry.isEmpty())
+    }
+
     @Test
     fun `different amino acid context yields different binder target and different match site`() {
         val firstBinder = interpretedBinderFrom("AAKRGKAA")

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -1,0 +1,92 @@
+package life.sim.biology.proteins
+
+import life.sim.biology.interactions.BondRegistry
+import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.interactions.bindingSurface
+import life.sim.biology.molecules.MRna
+import life.sim.biology.molecules.Polypeptide
+import life.sim.biology.primitives.NucleotideSequence
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProteinBindingTest {
+    @Test
+    fun `interpreted binder can create a runtime bond and register it`() {
+        val binder = interpretedBinderFrom("AAKRGKAA")
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(20))
+        val registry = BondRegistry()
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(99),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNotNull(bond)
+        assertEquals(1, registry.size)
+        assertEquals(bond, registry.toList().single())
+        assertTrue(bond.strength in 0.0..1.0)
+        assertEquals(0.05, bond.decayPerTick, absoluteTolerance = 1.0e-9)
+        assertEquals(MoleculeId(99), bond.left.moleculeId)
+        assertEquals(MoleculeId(20), bond.right.moleculeId)
+    }
+
+    @Test
+    fun `tryBind returns null and leaves registry unchanged when no complementary site exists`() {
+        val binder = interpretedBinderFrom("AAKRGKAA")
+        val target = MRna.of("AAAAAAA").bindingSurface(MoleculeId(30))
+        val registry = BondRegistry()
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(101),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNull(bond)
+        assertTrue(registry.isEmpty())
+    }
+
+    @Test
+    fun `different amino acid context yields different binder target and different match site`() {
+        val firstBinder = interpretedBinderFrom("AAKRGKAA")
+        val secondBinder = interpretedBinderFrom("AAKRGKDA")
+        val target = MRna.of(buildTargetWithOnlySecondMatch(secondBinder.bindingPattern)).bindingSurface(MoleculeId(31))
+        val registry = BondRegistry()
+
+        val firstBond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(201),
+            binder = firstBinder,
+            target = target,
+            registry = registry,
+        )
+        val secondBond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(202),
+            binder = secondBinder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNull(firstBond)
+        assertNotNull(secondBond)
+        assertEquals(1, registry.size)
+    }
+
+    private fun interpretedBinderFrom(sequence: String): SequenceBinder {
+        val domain = ProteinInterpreter.interpret(Polypeptide.of(sequence)).single()
+        return domain.capabilities.single() as SequenceBinder
+    }
+
+    private fun buildTargetWithOnlySecondMatch(pattern: NucleotideSequence): String {
+        return "AAAA${asText(pattern.complement())}AAAA"
+    }
+
+    private fun asText(sequence: NucleotideSequence): String =
+        sequence.toList().joinToString(separator = "") { it.symbol.toString() }
+}

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinInterpreterTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinInterpreterTest.kt
@@ -25,12 +25,24 @@ class ProteinInterpreterTest {
         assertEquals("BinderDomain", base.single().name)
         assertEquals("BinderDomain", mutated.single().name)
 
-        val baseAffinity = (base.single().capabilities.single() as SequenceBinder).affinity
-        val mutatedAffinity = (mutated.single().capabilities.single() as SequenceBinder).affinity
+        val baseBinder = base.single().capabilities.single() as SequenceBinder
+        val mutatedBinder = mutated.single().capabilities.single() as SequenceBinder
 
-        assertTrue(baseAffinity != mutatedAffinity)
+        assertTrue(baseBinder.affinity != mutatedBinder.affinity)
     }
 
+    @Test
+    fun `small mutation near motif alters binder target pattern`() {
+        val base = ProteinInterpreter.interpret(Polypeptide.of("AAKRGKAA"))
+        val mutated = ProteinInterpreter.interpret(Polypeptide.of("AAKRGKDA"))
+
+        val baseBinder = base.single().capabilities.single() as SequenceBinder
+        val mutatedBinder = mutated.single().capabilities.single() as SequenceBinder
+
+        assertTrue(baseBinder.bindingPattern != mutatedBinder.bindingPattern)
+        assertEquals(6, baseBinder.bindingPattern.size)
+        assertEquals(6, mutatedBinder.bindingPattern.size)
+    }
 
     @Test
     fun `interpreter detects ligase motif and clamps catalytic strength`() {

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -208,17 +208,19 @@ classDiagram
 
 ## Matching flow
 
-`BindingMatcher` still handles complementary sequence matching and site generation.
+`BindingMatcher` still handles complementary sequence matching and site generation, including
+`ProteinBinding.tryBind(...)` calls from interpreted `SequenceBinder` capabilities.
 
 ```mermaid
 flowchart LR
-    A[Pattern sequence] --> B[BindingMatcher]
+    A[SequenceBinder.bindingPattern] --> B[BindingMatcher]
     B --> C{Complementary match found?}
     C -- No --> D[Return -1 or null]
     C -- Yes --> E[Create SequenceRange]
     E --> F[Create BindingSite on target surface]
     F --> G[Create SiteEndpoint or mixed Bond]
     G --> H[Store in BondRegistry]
+    H --> I[Return created Bond]
 ```
 
 ---

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -115,6 +115,9 @@ A `Polypeptide` can be passed into `ProteinInterpreter` (in `life.sim.biology.pr
 The interpreter scans motif patterns and emits one or more `ProteinDomain`s, each of which exposes
 `MolecularCapability` values such as `SequenceBinder`, `Cutter`, `Ligase`, or `Blocker`.
 
+`SequenceBinder` capabilities now include a derived nucleotide `bindingPattern`, so interpreted binders
+carry concrete sequence targets that can be used during runtime matching.
+
 This keeps sequence storage separate from interpreted function and supports composing multiple
 capabilities from a single chain.
 
@@ -125,6 +128,9 @@ capabilities from a single chain.
 Molecule values describe structural identity.
 
 Runtime occupancy and binding state are modeled separately by the interactions layer (`BindingSurface`, `BindingSite`, `Bond`, `BondRegistry`).
+
+The `ProteinBinding.tryBind(...)` helper bridges interpretation to runtime associations by using a
+`SequenceBinder` pattern plus `BindingMatcher` to create and register concrete `Bond` values.
 
 That separation allows molecule values to remain immutable while runtime systems track transient binding dynamics.
 


### PR DESCRIPTION
### Motivation
- Connect interpreted protein binder descriptions to the runtime bond model so `SequenceBinder` domains can actually bind nucleotide surfaces. 
- Provide a minimal, deterministic path from `Polypeptide` interpretation to runtime `Bond` creation to enable follow-up capabilities (e.g., `Blocker`, `Cutter`, `Ligase`).

### Description
- Extended `SequenceBinder` to include a `bindingPattern: NucleotideSequence` so binders carry a concrete target sequence. 
- Updated `ProteinInterpreter` to derive a deterministic nucleotide pattern from the local amino-acid window via `deriveBinderPattern(...)` and attach it to produced `SequenceBinder` capabilities. 
- Added `ProteinBinding.tryBind(...)` which uses `BindingMatcher.complementaryMatchSite(...)` to locate the first compatible `BindingSite`, creates a `Bond` (mapping `affinity` → `strength`), registers it with `BondRegistry`, and returns the created `Bond` or `null` on no match. 
- Added tests (`ProteinBindingTest`, extended `ProteinInterpreterTest`) and documentation updates to cover pattern derivation, successful end-to-end binding, and no-match behavior. 

### Testing
- Ran `./gradlew :biology:test` and the test suite completed successfully. 
- New unit tests added for `ProteinBinding` and updated `ProteinInterpreter` tests passed under the same run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd5e671548329aff36c0d61fe0dd3)