### PR TITLE
Rewrite README to clarify project vision, structure, and current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,194 +1,120 @@
 # Life-Sim
 
-**Life-Sim** is an experimental artificial-life simulation where
-organisms evolve from compact, byte-encoded genomes.
+**Life-Sim** is an experimental artificial-life project focused on emergent
+biology-like behavior from simple, composable rules.
 
-The project explores how complex behaviors, structures, and learning
-can emerge when *everything*—from chemistry to cognition—is built from
-simple, composable units.
+The core research question is:
 
-> *How far can evolution go when both the code **and the machinery that executes it** are encoded in raw bytes?*
+> *How far can evolution go when both inherited data and the machinery that
+> interprets it are built from low-level building blocks?*
 
 ---
 
-## ✨ Core Ideas
+## Vision and Core Ideas
+
+While the implementation is still early, the long-term motivation remains
+ambitious. Life-Sim is intended to explore whether complex behavior can emerge
+from compact heredity plus simple, composable execution chemistry.
+
+Core ideas:
 
 * **Byte-encoded heredity**
-  Organisms store inheritable information in compact encoded forms.
-  Mutation, inheritance, and expression all operate directly on these
-  low-level representations.
-
-* **Genes as patterns, not instructions**
-  Genes are not necessarily executed directly. Instead, they define
-  patterns that can be interpreted, copied, or assembled by internal
-  biological machinery.
-
-* **Biology-inspired execution layer**
-  Organisms may include systems analogous to:
-
-    * Polymerases (copying / reading sequences)
-    * Ribosomes (assembling functional units)
-    * RNases / Nucleases (cutting and recycling)
-
-  These systems are *not hardcoded types*, but emerge from smaller
-  base-units and interactions.
-
-* **Base-units and emergent machinery**
-  The simulation aims to push toward a lower-level model where:
-
-    * Small building blocks ("base-units") define behavior
-    * Binding, matching, and catalysis emerge from molecule-to-molecule associations
-    * Complex machinery (like ribosomes) can evolve rather than be predefined
-    * Temporary complexes can form as dynamic networks of bonded molecules
-
-* **Evolvable neural and behavioral systems**
-  Organisms can form internal signaling and neural-like structures,
-  encoded in their hereditary information and shaped by evolution.
-
-* **Cells with physical structure**
-  Organisms consist of one or more connected cells with properties like:
-
-    * Membrane permeability
-    * Channels and pumps
-    * Spatial orientation
-    * Optional child cells forming multicellular structures
-
+  Organisms store inheritable information in compact encoded forms where
+  mutation, inheritance, and expression all work at low level.
+* **Genes as patterns, not only direct instructions**
+  Encoded sequences can be interpreted, copied, assembled, or repurposed by
+  internal machinery instead of mapping one-to-one to fixed commands.
+* **Emergent machinery over hardcoded roles**
+  Systems analogous to polymerases, ribosomes, and nucleases should ideally
+  arise from smaller parts and interactions, not from privileged built-ins.
+* **Binding/catalysis as the execution substrate**
+  Molecule-to-molecule associations, temporary complexes, and catalytic effects
+  are the intended foundation for higher-order behavior.
 * **Environment-driven adaptation**
-  The world provides nutrients, hazards, and gradients. Survival depends on:
+  The simulator aims to pressure organisms through resources, hazards, and
+  spatial constraints so survival depends on viable internal organization.
 
-    * Energy balance
-    * Resource acquisition
-    * Structural integrity
-    * Coordinated behavior
-
----
-
-## 🧬 Conceptual Layers
-
-Life-Sim separates *heritable descriptions* from *active biological processes*,
-even when both live inside the same module during early development:
-
-* **Biology module**
-  Hosts the current low-level sequence primitives, molecule types, and the
-  emerging genetics model. It defines how encoded sequences become active
-  processes through:
-
-    * Polymer formation (DNA/RNA/protein analogs)
-    * Binding and matching rules
-    * Catalytic behavior (copying, cutting, assembling)
-    * Decay and recycling
-
-* **Simulation module**
-  Defines the physical world in which organisms exist:
-
-    * Space, movement, diffusion
-    * Nutrients and hazards
-    * Interactions between organisms and environment
-
-This separation allows experimentation with different execution chemistries
-without tightly coupling sequence/molecule logic to the world simulation.
+This is the "north star" for the project and remains relevant even when current
+milestones focus on nearer-term building blocks.
 
 ---
 
-## 🧱 Project Structure
+## Current State (April 2026)
+
+The repository currently has a strong **biology foundation** and an early
+**simulator scaffold**:
+
+* **Biology primitives are implemented**
+  (`Nucleotide`, `NucleotideSequence`, ranges, directionality).
+* **Molecule models are implemented**
+  (DNA/RNA-like polymers, amino acids, polypeptides).
+* **Interaction mechanics are implemented**
+  (binding sites/surfaces/strands, bonds, matcher, bond registry).
+* **Protein interpretation has started**
+  with motif/domain-capability mapping in `ProteinInterpreter`.
+* **Simulator module exists**
+  but still contains placeholder/demo-level behavior compared with biology.
+
+The project is still intentionally exploratory and architecture may continue
+to evolve quickly.
+
+---
+
+## Project Structure
 
 ```
 life-sim/
-├─ biology/          # Primitives, molecules, genetics, and reaction systems
-├─ simulator/        # World model, physics, rendering, organism lifecycle
-└─ docs/             # Architecture notes, experiments, dev logs
+├─ biology/      # Sequence primitives, molecules, interactions, proteins
+├─ simulator/    # World/runtime module (early-stage scaffold)
+└─ docs/         # Design notes and evolving documentation
 ```
 
-### biology/
+Useful entry points:
 
-* Currently organized into low-level packages such as:
-
-    * `life.sim.biology.primitives` for sequence building blocks like `Nucleotide`, `NucleotideSequence`, and `SequenceDirection`
-    * `life.sim.biology.molecules` for molecule types like `Dna`, `MRna`, and `TRna`
-    * `life.sim.biology.interactions` for runtime molecule associations and bond-network behavior
-
-* Genetics-oriented representations and future mutation logic
-* Binding and matching rules
-* Machinery (emergent or constructed):
-
-    * Polymerases
-    * Ribosome-like assemblers
-    * RNase-like cutters
-* Reaction systems (copy, cut, bind, release)
-* Resource pools and recycling
-* Likely future package boundaries for genetics- and interaction-focused code as the biology layer grows
-
-### simulator/
-
-* Spatial world and physics
-* Diffusion of signals and resources
-* Cell and organism lifecycle
-* Integration of biology processes into time steps
+* `README.md` (this file) for high-level context.
+* `biology/README.md` for biology-module goals.
+* `simulator/README.md` for simulator-module goals.
+* `docs/README.md` and `docs/biology/*` for design notes.
 
 ---
 
-## 🧠 Design Philosophy
+## Roadmap
 
-Life-Sim is not trying to simulate biology accurately.
-Instead, it explores a question:
+Roadmap planning is tracked in **Issue #19**:
 
-> *What is the **minimum set of rules** required for something resembling life to emerge?*
+* <https://github.com/skasti/life-sim/issues/19>
 
-Key principles:
+That issue is the canonical source for near-term priorities and sequencing.
+At a high level, upcoming work centers on:
 
-* Avoid hardcoding high-level concepts ("ribosome", "neuron")
-* Prefer small, composable primitives
-* Let structure and behavior emerge from interactions
-* Keep the system evolvable at every layer
-
----
-
-## 🤖 AI-Assisted Development
-
-Life-Sim is developed collaboratively—partly by a human author, partly
-with the assistance of AI tools such as ChatGPT.
-
-AI contributes ideas, drafts, and refactor suggestions, while the human
-developer makes final architectural decisions.
+* expanding reaction/execution chemistry,
+* connecting biology dynamics into richer simulation ticks, and
+* improving architecture/docs as modules mature.
 
 ---
 
-## 🚧 Status
+## Design Philosophy
 
-This project is in **early development**.
+Life-Sim does **not** aim to be a biologically accurate simulator. Instead, it
+aims to discover minimal rule sets that can produce lifelike complexity.
 
-The biological execution layer is actively evolving and may change
-significantly as new models are explored.
+Principles:
 
-The internal package layout of `biology` is also still evolving; today it is
-split into areas such as `biology.primitives` and `biology.molecules`, with
-room for future genetics and interaction packages.
-
----
-
-## 📜 License
-
-This project is released under the **Creative Commons BY-NC 4.0** license.
-
-You may use and modify it for non-commercial purposes with proper
-attribution.
+* Prefer composable primitives over hardcoded high-level entities.
+* Let structure emerge through interactions and constraints.
+* Keep every layer evolvable (representation, execution, behavior).
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-This is currently a personal research project, but ideas, suggestions,
-and discussions are welcome via Issues or PRs.
+The project is currently personal and research-oriented, but feedback and PRs
+are welcome.
+
+See `CONTRIBUTING.md` for process details.
 
 ---
 
-## 🧠 Motivation
+## License
 
-Life-Sim is inspired by:
-
-* Biological evolution
-* Minimalist virtual machines
-* Emergent behavior in complex systems
-* Curiosity about how "intelligence" forms from simple parts
-
-If those ideas excite you, feel free to follow along.
+This project is licensed under **Creative Commons BY-NC 4.0**.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,11 @@ At a high level, upcoming work centers on:
 
 ## Design Philosophy
 
-Life-Sim does **not** aim to be a biologically accurate simulator. Instead, it
-aims to discover minimal rule sets that can produce lifelike complexity.
+Life-Sim is heavily inspired by real biology and aims to stay as biologically
+grounded as practical. It still does **not** aim for full biological fidelity
+or to simulate every mechanism (for example, detailed protein folding);
+instead, it focuses on discovering minimal rule sets that can produce lifelike
+complexity.
 
 Principles:
 


### PR DESCRIPTION
### Motivation

- Clarify the project's long-term research goals and provide a concise, maintainable entrypoint for newcomers.  
- Replace fragmented, evolving notes with a clearer high-level description that reflects current implementation progress.  
- Surface near-term priorities and contributor guidance via a canonical roadmap reference.

### Description

- Replace the original README with a reorganized document that emphasizes a focused vision under "Vision and Core Ideas" and a concise "Current State (April 2026)" summary.  
- Condense detailed conceptual sections into core ideas such as byte-encoded heredity, emergent machinery, and binding/catalysis as an execution substrate.  
- Update project structure and useful entry points to mention `biology/`, `simulator/`, `docs/`, and call out implemented primitives like `Nucleotide`, `NucleotideSequence`, molecule models, and `ProteinInterpreter`.  
- Add a roadmap link to `Issue #19`, clarify design philosophy, and update contributing and license pointers (keeping `Creative Commons BY-NC 4.0`).

### Testing

- No automated unit tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdc2cc4f483298522ffbe88e48b54)