### PR TITLE
Add conflict-aware occupancy resolution for sequence binding

### DIFF
--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -31,8 +31,13 @@ object ProteinBinding {
 
         val overlapping = registry.overlapping(targetSite)
         val strongestOverlap = overlapping.maxOfOrNull(Bond::strength)
+        val conflictThreshold = if (normalizedStrength > CONFLICT_EPSILON) {
+            normalizedStrength - CONFLICT_EPSILON
+        } else {
+            normalizedStrength
+        }
 
-        if (strongestOverlap != null && strongestOverlap >= normalizedStrength - CONFLICT_EPSILON) {
+        if (strongestOverlap != null && strongestOverlap >= conflictThreshold) {
             return null
         }
 

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -37,13 +37,6 @@ object ProteinBinding {
         binder: SequenceBinder,
         target: BindingSurface,
         registry: BondRegistry,
-    ): Bond? = tryBindWithConflicts(proteinId, binder, target, registry).bond
-
-    fun tryBindWithConflicts(
-        proteinId: MoleculeId,
-        binder: SequenceBinder,
-        target: BindingSurface,
-        registry: BondRegistry,
     ): BindingDecision {
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)
             ?: return BindingDecision(outcome = BindingOutcome.REJECTED_NO_SITE)

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -9,23 +9,6 @@ import life.sim.biology.interactions.SiteEndpoint
 import life.sim.biology.interactions.WholeMoleculeEndpoint
 
 /**
- * Result of a conflict-aware runtime bind attempt.
- */
-data class BindingDecision(
-    val outcome: BindingOutcome,
-    val bond: Bond? = null,
-    val displaced: List<Bond> = emptyList(),
-)
-
-enum class BindingOutcome {
-    BOUND,
-    BOUND_AFTER_DISPLACEMENT,
-    REJECTED_NO_SITE,
-    REJECTED_INACTIVE_STRENGTH,
-    REJECTED_CONFLICT,
-}
-
-/**
  * Runtime bridge from interpreted protein capabilities to concrete bonds.
  */
 object ProteinBinding {
@@ -37,20 +20,20 @@ object ProteinBinding {
         binder: SequenceBinder,
         target: BindingSurface,
         registry: BondRegistry,
-    ): BindingDecision {
+    ): Bond? {
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)
-            ?: return BindingDecision(outcome = BindingOutcome.REJECTED_NO_SITE)
+            ?: return null
 
         val normalizedStrength = binder.affinity.coerceIn(0.0, 1.0)
         if (normalizedStrength <= 0.0) {
-            return BindingDecision(outcome = BindingOutcome.REJECTED_INACTIVE_STRENGTH)
+            return null
         }
 
         val overlapping = registry.overlapping(targetSite)
         val strongestOverlap = overlapping.maxOfOrNull(Bond::strength)
 
         if (strongestOverlap != null && strongestOverlap >= normalizedStrength - CONFLICT_EPSILON) {
-            return BindingDecision(outcome = BindingOutcome.REJECTED_CONFLICT)
+            return null
         }
 
         overlapping.forEach(registry::remove)
@@ -64,10 +47,6 @@ object ProteinBinding {
 
         registry.add(bond)
 
-        return BindingDecision(
-            outcome = if (overlapping.isEmpty()) BindingOutcome.BOUND else BindingOutcome.BOUND_AFTER_DISPLACEMENT,
-            bond = bond,
-            displaced = overlapping,
-        )
+        return bond
     }
 }

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -9,23 +9,58 @@ import life.sim.biology.interactions.SiteEndpoint
 import life.sim.biology.interactions.WholeMoleculeEndpoint
 
 /**
+ * Result of a conflict-aware runtime bind attempt.
+ */
+data class BindingDecision(
+    val outcome: BindingOutcome,
+    val bond: Bond? = null,
+    val displaced: List<Bond> = emptyList(),
+)
+
+enum class BindingOutcome {
+    BOUND,
+    BOUND_AFTER_DISPLACEMENT,
+    REJECTED_NO_SITE,
+    REJECTED_INACTIVE_STRENGTH,
+    REJECTED_CONFLICT,
+}
+
+/**
  * Runtime bridge from interpreted protein capabilities to concrete bonds.
  */
 object ProteinBinding {
     private const val DEFAULT_DECAY_PER_TICK = 0.05
+    private const val CONFLICT_EPSILON = 1.0e-9
 
     fun tryBind(
         proteinId: MoleculeId,
         binder: SequenceBinder,
         target: BindingSurface,
         registry: BondRegistry,
-    ): Bond? {
-        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target) ?: return null
+    ): Bond? = tryBindWithConflicts(proteinId, binder, target, registry).bond
+
+    fun tryBindWithConflicts(
+        proteinId: MoleculeId,
+        binder: SequenceBinder,
+        target: BindingSurface,
+        registry: BondRegistry,
+    ): BindingDecision {
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)
+            ?: return BindingDecision(outcome = BindingOutcome.REJECTED_NO_SITE)
 
         val normalizedStrength = binder.affinity.coerceIn(0.0, 1.0)
         if (normalizedStrength <= 0.0) {
-            return null
+            return BindingDecision(outcome = BindingOutcome.REJECTED_INACTIVE_STRENGTH)
         }
+
+        val overlapping = registry.overlapping(targetSite)
+        val strongestOverlap = overlapping.maxOfOrNull(Bond::strength)
+
+        if (strongestOverlap != null && strongestOverlap >= normalizedStrength - CONFLICT_EPSILON) {
+            return BindingDecision(outcome = BindingOutcome.REJECTED_CONFLICT)
+        }
+
+        overlapping.forEach(registry::remove)
 
         val bond = Bond(
             left = WholeMoleculeEndpoint(proteinId),
@@ -35,6 +70,11 @@ object ProteinBinding {
         )
 
         registry.add(bond)
-        return bond
+
+        return BindingDecision(
+            outcome = if (overlapping.isEmpty()) BindingOutcome.BOUND else BindingOutcome.BOUND_AFTER_DISPLACEMENT,
+            bond = bond,
+            displaced = overlapping,
+        )
     }
 }

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -24,16 +24,13 @@ class ProteinBindingTest {
         val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(20))
         val registry = BondRegistry()
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(99),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.BOUND, decision.outcome)
-        assertTrue(decision.displaced.isEmpty())
-        val bond = decision.bond
         assertNotNull(bond)
         assertEquals(1, registry.size)
         assertEquals(bond, registry.toList().single())
@@ -49,15 +46,14 @@ class ProteinBindingTest {
         val target = MRna.of("AAAAAAA").bindingSurface(MoleculeId(30))
         val registry = BondRegistry()
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(101),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.REJECTED_NO_SITE, decision.outcome)
-        assertEquals(null, decision.bond)
+        assertNull(bond)
         assertTrue(registry.isEmpty())
     }
 
@@ -67,15 +63,14 @@ class ProteinBindingTest {
         val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(32))
         val registry = BondRegistry()
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(203),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.REJECTED_INACTIVE_STRENGTH, decision.outcome)
-        assertEquals(null, decision.bond)
+        assertNull(bond)
         assertTrue(registry.isEmpty())
     }
 
@@ -86,23 +81,21 @@ class ProteinBindingTest {
         val target = MRna.of(buildTargetWithOnlySecondMatch(secondBinder.bindingPattern)).bindingSurface(MoleculeId(31))
         val registry = BondRegistry()
 
-        val firstDecision = ProteinBinding.tryBind(
+        val firstBond = ProteinBinding.tryBind(
             proteinId = MoleculeId(201),
             binder = firstBinder,
             target = target,
             registry = registry,
         )
-        val secondDecision = ProteinBinding.tryBind(
+        val secondBond = ProteinBinding.tryBind(
             proteinId = MoleculeId(202),
             binder = secondBinder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.REJECTED_NO_SITE, firstDecision.outcome)
-        assertEquals(null, firstDecision.bond)
-        assertEquals(BindingOutcome.BOUND, secondDecision.outcome)
-        assertNotNull(secondDecision.bond)
+        assertNull(firstBond)
+        assertNotNull(secondBond)
         assertEquals(1, registry.size)
     }
 
@@ -119,16 +112,14 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(strongerOccupant))
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(501),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.REJECTED_CONFLICT, decision.outcome)
-        assertNull(decision.bond)
-        assertTrue(decision.displaced.isEmpty())
+        assertNull(bond)
         assertEquals(listOf(strongerOccupant), registry.toList())
     }
 
@@ -145,17 +136,15 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(weakerOccupant))
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(511),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.BOUND_AFTER_DISPLACEMENT, decision.outcome)
-        assertEquals(listOf(weakerOccupant), decision.displaced)
-        assertNotNull(decision.bond)
-        assertEquals(listOf(decision.bond), registry.toList())
+        assertNotNull(bond)
+        assertEquals(listOf(bond), registry.toList())
     }
 
     @Test
@@ -177,19 +166,17 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(overlappingWeak, nonOverlapping))
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(522),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.BOUND_AFTER_DISPLACEMENT, decision.outcome)
-        assertEquals(listOf(overlappingWeak), decision.displaced)
-        assertNotNull(decision.bond)
+        assertNotNull(bond)
         assertEquals(2, registry.size)
         assertTrue(registry.toList().contains(nonOverlapping))
-        assertTrue(registry.toList().contains(decision.bond))
+        assertTrue(registry.toList().contains(bond))
     }
 
     @Test
@@ -205,14 +192,14 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(existing))
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(531),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.REJECTED_CONFLICT, decision.outcome)
+        assertNull(bond)
         assertEquals(listOf(existing), registry.toList())
     }
 
@@ -236,17 +223,15 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(overlappingFirst, overlappingSecond))
 
-        val decision = ProteinBinding.tryBind(
+        val bond = ProteinBinding.tryBind(
             proteinId = MoleculeId(542),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertEquals(BindingOutcome.BOUND_AFTER_DISPLACEMENT, decision.outcome)
-        assertEquals(setOf(overlappingFirst, overlappingSecond), decision.displaced.toSet())
-        assertNotNull(decision.bond)
-        assertEquals(listOf(decision.bond), registry.toList())
+        assertNotNull(bond)
+        assertEquals(listOf(bond), registry.toList())
     }
 
     private fun interpretedBinderFrom(sequence: String): SequenceBinder {

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -203,6 +203,32 @@ class ProteinBindingTest {
         assertEquals(listOf(existing), registry.toList())
     }
 
+
+    @Test
+    fun `sub-epsilon affinity still displaces weaker overlap`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 5.0e-10)
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(45))
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
+        val weakerOccupant = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(550)),
+            right = SiteEndpoint(targetSite),
+            strength = 1.0e-12,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(weakerOccupant))
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(551),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNotNull(bond)
+        assertEquals(5.0e-10, bond.strength, absoluteTolerance = 1.0e-15)
+        assertEquals(listOf(bond), registry.toList())
+    }
+
     @Test
     fun `multiple overlapping weaker occupants are displaced together`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.95)

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -24,13 +24,16 @@ class ProteinBindingTest {
         val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(20))
         val registry = BondRegistry()
 
-        val bond = ProteinBinding.tryBind(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(99),
             binder = binder,
             target = target,
             registry = registry,
         )
 
+        assertEquals(BindingOutcome.BOUND, decision.outcome)
+        assertTrue(decision.displaced.isEmpty())
+        val bond = decision.bond
         assertNotNull(bond)
         assertEquals(1, registry.size)
         assertEquals(bond, registry.toList().single())
@@ -41,36 +44,38 @@ class ProteinBindingTest {
     }
 
     @Test
-    fun `tryBind returns null and leaves registry unchanged when no complementary site exists`() {
+    fun `tryBind rejects and leaves registry unchanged when no complementary site exists`() {
         val binder = interpretedBinderFrom("AAKRGKAA")
         val target = MRna.of("AAAAAAA").bindingSurface(MoleculeId(30))
         val registry = BondRegistry()
 
-        val bond = ProteinBinding.tryBind(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(101),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertNull(bond)
+        assertEquals(BindingOutcome.REJECTED_NO_SITE, decision.outcome)
+        assertEquals(null, decision.bond)
         assertTrue(registry.isEmpty())
     }
 
     @Test
-    fun `tryBind returns null when affinity normalizes to inactive bond strength`() {
+    fun `tryBind rejects when affinity normalizes to inactive bond strength`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.0)
         val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(32))
         val registry = BondRegistry()
 
-        val bond = ProteinBinding.tryBind(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(203),
             binder = binder,
             target = target,
             registry = registry,
         )
 
-        assertNull(bond)
+        assertEquals(BindingOutcome.REJECTED_INACTIVE_STRENGTH, decision.outcome)
+        assertEquals(null, decision.bond)
         assertTrue(registry.isEmpty())
     }
 
@@ -81,21 +86,23 @@ class ProteinBindingTest {
         val target = MRna.of(buildTargetWithOnlySecondMatch(secondBinder.bindingPattern)).bindingSurface(MoleculeId(31))
         val registry = BondRegistry()
 
-        val firstBond = ProteinBinding.tryBind(
+        val firstDecision = ProteinBinding.tryBind(
             proteinId = MoleculeId(201),
             binder = firstBinder,
             target = target,
             registry = registry,
         )
-        val secondBond = ProteinBinding.tryBind(
+        val secondDecision = ProteinBinding.tryBind(
             proteinId = MoleculeId(202),
             binder = secondBinder,
             target = target,
             registry = registry,
         )
 
-        assertNull(firstBond)
-        assertNotNull(secondBond)
+        assertEquals(BindingOutcome.REJECTED_NO_SITE, firstDecision.outcome)
+        assertEquals(null, firstDecision.bond)
+        assertEquals(BindingOutcome.BOUND, secondDecision.outcome)
+        assertNotNull(secondDecision.bond)
         assertEquals(1, registry.size)
     }
 
@@ -112,7 +119,7 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(strongerOccupant))
 
-        val decision = ProteinBinding.tryBindWithConflicts(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(501),
             binder = binder,
             target = target,
@@ -138,7 +145,7 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(weakerOccupant))
 
-        val decision = ProteinBinding.tryBindWithConflicts(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(511),
             binder = binder,
             target = target,
@@ -170,7 +177,7 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(overlappingWeak, nonOverlapping))
 
-        val decision = ProteinBinding.tryBindWithConflicts(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(522),
             binder = binder,
             target = target,
@@ -198,7 +205,7 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(existing))
 
-        val decision = ProteinBinding.tryBindWithConflicts(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(531),
             binder = binder,
             target = target,
@@ -229,7 +236,7 @@ class ProteinBindingTest {
         )
         val registry = BondRegistry(listOf(overlappingFirst, overlappingSecond))
 
-        val decision = ProteinBinding.tryBindWithConflicts(
+        val decision = ProteinBinding.tryBind(
             proteinId = MoleculeId(542),
             binder = binder,
             target = target,

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -1,7 +1,11 @@
 package life.sim.biology.proteins
 
+import life.sim.biology.interactions.BindingMatcher
+import life.sim.biology.interactions.Bond
 import life.sim.biology.interactions.BondRegistry
 import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.interactions.SiteEndpoint
+import life.sim.biology.interactions.WholeMoleculeEndpoint
 import life.sim.biology.interactions.bindingSurface
 import life.sim.biology.molecules.MRna
 import life.sim.biology.molecules.Polypeptide
@@ -53,7 +57,6 @@ class ProteinBindingTest {
         assertTrue(registry.isEmpty())
     }
 
-
     @Test
     fun `tryBind returns null when affinity normalizes to inactive bond strength`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.0)
@@ -94,6 +97,149 @@ class ProteinBindingTest {
         assertNull(firstBond)
         assertNotNull(secondBond)
         assertEquals(1, registry.size)
+    }
+
+    @Test
+    fun `weaker binder does not displace stronger overlapping bond`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.4)
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(40))
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
+        val strongerOccupant = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(500)),
+            right = SiteEndpoint(targetSite),
+            strength = 0.9,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(strongerOccupant))
+
+        val decision = ProteinBinding.tryBindWithConflicts(
+            proteinId = MoleculeId(501),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertEquals(BindingOutcome.REJECTED_CONFLICT, decision.outcome)
+        assertNull(decision.bond)
+        assertTrue(decision.displaced.isEmpty())
+        assertEquals(listOf(strongerOccupant), registry.toList())
+    }
+
+    @Test
+    fun `stronger binder displaces weaker overlapping bond`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.9)
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(41))
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
+        val weakerOccupant = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(510)),
+            right = SiteEndpoint(targetSite),
+            strength = 0.3,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(weakerOccupant))
+
+        val decision = ProteinBinding.tryBindWithConflicts(
+            proteinId = MoleculeId(511),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertEquals(BindingOutcome.BOUND_AFTER_DISPLACEMENT, decision.outcome)
+        assertEquals(listOf(weakerOccupant), decision.displaced)
+        assertNotNull(decision.bond)
+        assertEquals(listOf(decision.bond), registry.toList())
+    }
+
+    @Test
+    fun `non-overlapping bonds remain when overlapping weaker bond is displaced`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.8)
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CCAA").bindingSurface(MoleculeId(42))
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
+        val overlappingWeak = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(520)),
+            right = SiteEndpoint(targetSite),
+            strength = 0.4,
+            decayPerTick = 0.05,
+        )
+        val nonOverlapping = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(521)),
+            right = SiteEndpoint(target.site(targetSite.range.endExclusive, target.length)),
+            strength = 0.9,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(overlappingWeak, nonOverlapping))
+
+        val decision = ProteinBinding.tryBindWithConflicts(
+            proteinId = MoleculeId(522),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertEquals(BindingOutcome.BOUND_AFTER_DISPLACEMENT, decision.outcome)
+        assertEquals(listOf(overlappingWeak), decision.displaced)
+        assertNotNull(decision.bond)
+        assertEquals(2, registry.size)
+        assertTrue(registry.toList().contains(nonOverlapping))
+        assertTrue(registry.toList().contains(decision.bond))
+    }
+
+    @Test
+    fun `equal strength overlap keeps existing bond deterministically`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.6)
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(43))
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
+        val existing = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(530)),
+            right = SiteEndpoint(targetSite),
+            strength = 0.6,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(existing))
+
+        val decision = ProteinBinding.tryBindWithConflicts(
+            proteinId = MoleculeId(531),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertEquals(BindingOutcome.REJECTED_CONFLICT, decision.outcome)
+        assertEquals(listOf(existing), registry.toList())
+    }
+
+    @Test
+    fun `multiple overlapping weaker occupants are displaced together`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.95)
+        val target = MRna.of("UU${asText(binder.bindingPattern.complement())}GG").bindingSurface(MoleculeId(44))
+        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
+
+        val overlappingFirst = Bond(
+            left = SiteEndpoint(target.site(targetSite.range.start, targetSite.range.start + 2)),
+            right = WholeMoleculeEndpoint(MoleculeId(540)),
+            strength = 0.3,
+            decayPerTick = 0.05,
+        )
+        val overlappingSecond = Bond(
+            left = SiteEndpoint(target.site(targetSite.range.endExclusive - 2, targetSite.range.endExclusive)),
+            right = WholeMoleculeEndpoint(MoleculeId(541)),
+            strength = 0.4,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(overlappingFirst, overlappingSecond))
+
+        val decision = ProteinBinding.tryBindWithConflicts(
+            proteinId = MoleculeId(542),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertEquals(BindingOutcome.BOUND_AFTER_DISPLACEMENT, decision.outcome)
+        assertEquals(setOf(overlappingFirst, overlappingSecond), decision.displaced.toSet())
+        assertNotNull(decision.bond)
+        assertEquals(listOf(decision.bond), registry.toList())
     }
 
     private fun interpretedBinderFrom(sequence: String): SequenceBinder {

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -318,7 +318,7 @@ The current model supports both occupancy and connectivity:
 
 Current limitations include:
 
-- no affinity-scoring or competitive binding policy yet
+- a basic competitive overlap policy exists for site occupancy, but richer affinity-scoring and higher-level binding/blockage policies are not yet modeled
 - registry is still in-memory and not yet integrated with broader simulation state
 - complex membership derivation is not yet packaged as a dedicated helper API
 

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -215,37 +215,33 @@ classDiagram
 flowchart LR
     A[SequenceBinder.bindingPattern] --> B[BindingMatcher]
     B --> C{Complementary match found?}
-    C -- No --> D[BindingDecision: REJECTED_NO_SITE]
+    C -- No --> D[Return null]
     C -- Yes --> E[Create SequenceRange]
     E --> F[Create BindingSite on target surface]
     F --> G{Affinity > 0?}
-    G -- No --> H[BindingDecision: REJECTED_INACTIVE_STRENGTH]
+    G -- No --> H[Return null]
     G -- Yes --> I{Stronger/equal overlap exists?}
-    I -- Yes --> J[BindingDecision: REJECTED_CONFLICT]
+    I -- Yes --> J[Return null]
     I -- No --> K[Remove weaker overlapping bonds]
     K --> L[Create and store Bond]
-    L --> M[BindingDecision: BOUND or BOUND_AFTER_DISPLACEMENT]
+    L --> M[Return Bond]
 ```
 
 ---
 
-## `ProteinBinding.tryBind(...)` outcome model
+## `ProteinBinding.tryBind(...)` return model
 
-`ProteinBinding.tryBind(...)` now returns a `BindingDecision` instead of `Bond?`.
+`ProteinBinding.tryBind(...)` returns a nullable `Bond`.
 
-`BindingDecision` contains:
+The return contract is:
 
-- `outcome: BindingOutcome` — high-level result of the bind attempt
-- `bond: Bond?` — populated only for successful outcomes
-- `displaced: List<Bond>` — weaker overlapping bonds removed during successful displacement
+- returns a `Bond` when matching succeeds and occupancy checks pass
+- returns `null` when there is no complementary site, the affinity normalizes to inactive (`<= 0`), or an equal/stronger overlapping bond occupies the region
 
-`BindingOutcome` values:
+Conflict resolution still happens inside `ProteinBinding` by mutating `BondRegistry`:
 
-- `BOUND`: binding succeeded without displacing an existing overlapping bond
-- `BOUND_AFTER_DISPLACEMENT`: binding succeeded after removing one or more weaker overlaps
-- `REJECTED_NO_SITE`: no complementary site was found on the target surface
-- `REJECTED_INACTIVE_STRENGTH`: binder affinity resolved to inactive strength (`<= 0`)
-- `REJECTED_CONFLICT`: an equal- or stronger overlapping bond already occupied the site
+- weaker overlapping bonds are removed before creating a stronger replacement bond
+- callers can validate side effects by inspecting registry state rather than consuming a displaced-bonds payload
 
 ---
 

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -215,13 +215,37 @@ classDiagram
 flowchart LR
     A[SequenceBinder.bindingPattern] --> B[BindingMatcher]
     B --> C{Complementary match found?}
-    C -- No --> D[Return -1 or null]
+    C -- No --> D[BindingDecision: REJECTED_NO_SITE]
     C -- Yes --> E[Create SequenceRange]
     E --> F[Create BindingSite on target surface]
-    F --> G[Create SiteEndpoint or mixed Bond]
-    G --> H[Store in BondRegistry]
-    H --> I[Return created Bond]
+    F --> G{Affinity > 0?}
+    G -- No --> H[BindingDecision: REJECTED_INACTIVE_STRENGTH]
+    G -- Yes --> I{Stronger/equal overlap exists?}
+    I -- Yes --> J[BindingDecision: REJECTED_CONFLICT]
+    I -- No --> K[Remove weaker overlapping bonds]
+    K --> L[Create and store Bond]
+    L --> M[BindingDecision: BOUND or BOUND_AFTER_DISPLACEMENT]
 ```
+
+---
+
+## `ProteinBinding.tryBind(...)` outcome model
+
+`ProteinBinding.tryBind(...)` now returns a `BindingDecision` instead of `Bond?`.
+
+`BindingDecision` contains:
+
+- `outcome: BindingOutcome` — high-level result of the bind attempt
+- `bond: Bond?` — populated only for successful outcomes
+- `displaced: List<Bond>` — weaker overlapping bonds removed during successful displacement
+
+`BindingOutcome` values:
+
+- `BOUND`: binding succeeded without displacing an existing overlapping bond
+- `BOUND_AFTER_DISPLACEMENT`: binding succeeded after removing one or more weaker overlaps
+- `REJECTED_NO_SITE`: no complementary site was found on the target surface
+- `REJECTED_INACTIVE_STRENGTH`: binder affinity resolved to inactive strength (`<= 0`)
+- `REJECTED_CONFLICT`: an equal- or stronger overlapping bond already occupied the site
 
 ---
 
@@ -298,7 +322,6 @@ The current model supports both occupancy and connectivity:
 
 Current limitations include:
 
-- no built-in conflict resolution beyond explicit query/filter logic
 - no affinity-scoring or competitive binding policy yet
 - registry is still in-memory and not yet integrated with broader simulation state
 - complex membership derivation is not yet packaged as a dedicated helper API


### PR DESCRIPTION
This pull request introduces a competitive binding policy for protein binding in the simulation, ensuring that only the strongest bond occupies a binding site and that weaker or equal-strength bonds are not able to displace stronger ones. It also adds comprehensive tests for these behaviors and updates documentation to reflect the new binding logic.

**Competitive binding logic:**
- Implemented a competitive overlap policy in `ProteinBinding.tryBind`, so that a new bond can only be formed if it is stronger than any overlapping existing bonds. Weaker or equal-strength binders are rejected, and only weaker overlapping bonds are removed and replaced by stronger ones.

**Testing enhancements:**
- Added multiple tests to `ProteinBindingTest` to verify that:
  - Weaker binders cannot displace stronger overlapping bonds.
  - Stronger binders successfully displace weaker overlapping bonds.
  - Non-overlapping bonds remain unaffected when an overlapping weaker bond is displaced.
  - Equal-strength overlaps deterministically keep the existing bond.
  - Multiple weaker overlapping bonds are displaced together by a stronger binder.

**Documentation updates:**
- Updated the flowchart and narrative in `docs/biology/interactions/bonds.md` to describe the new competitive binding and conflict resolution model, including the return contract of `ProteinBinding.tryBind` and its side effects on `BondRegistry`. [[1]](diffhunk://#diff-bf288586f5d8d4546e4989cae4cc05337db161b4cb1d6a9476c6d25ca9caa01cL218-R247) [[2]](diffhunk://#diff-bf288586f5d8d4546e4989cae4cc05337db161b4cb1d6a9476c6d25ca9caa01cL301-R321)

**Test and code clarity:**
- Improved test naming and descriptions for clarity regarding rejection cases (e.g., no complementary site, inactive affinity). [[1]](diffhunk://#diff-9043335567875a4368f7f0ad4a8e2dd9531df5b5c02454da19fe644eabfdc62aL40-R44) [[2]](diffhunk://#diff-9043335567875a4368f7f0ad4a8e2dd9531df5b5c02454da19fe644eabfdc62aL56-R61)

**Imports and setup:**
- Added missing imports in `ProteinBindingTest.kt` to support new test cases.