### PR TITLE
Add agent instruction files for Codex and GitHub Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,42 @@
+# GitHub Copilot instructions for Life-Sim
+
+## Goal
+Help contributors produce focused, biologically grounded changes that align with Life-Sim's long-term direction.
+
+## Repository context
+
+- Core modules:
+  - `biology`: sequence primitives, molecules, interactions, proteins.
+  - `simulator`: world/runtime orchestration.
+- Strategic references:
+  - Root `README.md`
+  - `biology/README.md`
+  - `simulator/README.md`
+  - `docs/README.md`
+  - Roadmap: GitHub Issue #19
+
+## Implementation guidelines
+
+1. Avoid broad refactors unless requested by task requirements or maintainers.
+2. Keep PRs focused and cohesive.
+3. If code behavior changes, update the relevant docs in the same change.
+4. Prefer simple composable building blocks over hardcoded high-level mechanisms.
+5. When reasonable, choose designs that support future roadmap evolution over narrow one-off specialization.
+
+## Module boundaries
+
+- Keep `biology` independent from simulator/world/rendering concerns.
+- Keep simulator-specific orchestration in `simulator`.
+- Preserve deterministic behavior where practical in biology-domain logic.
+
+## Testing and review guidance
+
+- Add/adjust tests when changing logic.
+- Ensure test names clearly state what is tested and match actual APIs.
+- Verify documentation remains consistent with behavior.
+- Prefer comments explaining intent/rationale (`why`) rather than restating implementation (`what`).
+
+## PR quality
+
+- Summarize user-visible or behavior changes clearly.
+- Call out assumptions and follow-up work when a design is intentionally partial.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ Help contributors produce focused, biologically grounded changes that align with
   - `biology/README.md`
   - `simulator/README.md`
   - `docs/README.md`
-  - Roadmap: GitHub Issue #19
+  - Roadmap: [GitHub Issue #19](https://github.com/<OWNER>/<REPO>/issues/19)
 
 ## Implementation guidelines
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ Help contributors produce focused, biologically grounded changes that align with
   - `biology/README.md`
   - `simulator/README.md`
   - `docs/README.md`
-  - Roadmap: [GitHub Issue #19](https://github.com/<OWNER>/<REPO>/issues/19)
+  - Roadmap: [GitHub Issue #19](https://github.com/skasti/life-sim/issues/19)
 
 ## Implementation guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS Instructions for Life-Sim
+
+These instructions are for coding agents (for example Codex) operating in this repository.
+Scope: this entire repository unless overridden by a more specific nested `AGENTS.md`.
+
+## Project intent
+
+Life-Sim explores emergent biology-like behavior from simple, composable building blocks.
+Use the roadmap in GitHub Issue #19 and the root `README.md` as strategic context.
+
+## Change guidelines
+
+1. Avoid wide-spread refactors unless the task explicitly asks for it or maintainers approve it.
+2. Keep changes focused and minimal; prefer small, reviewable commits.
+3. When implementing or changing behavior, update relevant docs in the same PR.
+4. Prefer composition over hardcoded specialized entities.
+   - Build small reusable mechanisms that can self-assemble into higher-order behavior.
+   - Avoid introducing privileged high-level types unless explicitly required.
+5. Prefer future-proof abstractions over one-off specialization when it does not overcomplicate the current change.
+
+## Architecture boundaries
+
+- `biology` should remain pure domain logic and stay simulator-agnostic.
+- `simulator` may orchestrate world/environment behavior and call into `biology`.
+- Do not introduce `simulator` dependencies into `biology`.
+
+## Code review checklist
+
+- Test names should clearly describe the behavior under test and reference the correct type/method names.
+- Code behavior must match documentation; if behavior changes, docs must be updated.
+- Add comments where useful, preferring **why** over **what**.
+- Keep naming and package organization consistent with existing Kotlin style.
+
+## Testing expectations
+
+- Run relevant tests for touched modules.
+- Prefer adding or updating tests whenever core logic changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Scope: this entire repository unless overridden by a more specific nested `AGENT
 ## Project intent
 
 Life-Sim explores emergent biology-like behavior from simple, composable building blocks.
-Use the roadmap in GitHub Issue #19 and the root `README.md` as strategic context.
+Use the roadmap linked from the root `README.md` as strategic context.
 
 ## Change guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Use the roadmap in GitHub Issue #19 and the root `README.md` as strategic contex
 
 ## Change guidelines
 
-1. Avoid wide-spread refactors unless the task explicitly asks for it or maintainers approve it.
+1. Avoid widespread refactors unless the task explicitly asks for it or maintainers approve it.
 2. Keep changes focused and minimal; prefer small, reviewable commits.
 3. When implementing or changing behavior, update relevant docs in the same PR.
 4. Prefer composition over hardcoded specialized entities.


### PR DESCRIPTION
### Motivation
- Provide repository-level guidance so AI-assisted contributors (Codex/Copilot) follow the project’s architectural boundaries, change guidelines, and review/testing expectations. 

### Description
- Add `AGENTS.md` at the repository root with instructions for Codex-style agents covering change scope, documentation upkeep, composition-first design, `biology`/`simulator` boundaries, and review checklist. 
- Add `.github/copilot-instructions.md` with matching guidance tailored for GitHub Copilot usage. 
- This is a documentation-only change and does not modify runtime code or behavior. 

### Testing
- No automated tests were run because this is a docs-only change; basic repository checks and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08180b6ac8329902c6746fa5380dd)