### PR TITLE
Add viable-site scanning for sequence binding

### DIFF
--- a/biology/src/main/kotlin/life/sim/biology/interactions/BindingMatcher.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BindingMatcher.kt
@@ -36,12 +36,34 @@ object BindingMatcher {
     }
 
     fun complementaryMatchSite(pattern: NucleotideSequence, surface: BindingSurface): BindingSite? {
-        val start = complementaryMatchStart(pattern, surface.sequence)
-        return if (start < 0) {
-            null
-        } else {
-            BindingSite(surface, SequenceRange(start, start + pattern.size))
+        return complementaryMatchSites(pattern, surface).firstOrNull()
+    }
+
+    fun complementaryMatchSites(pattern: NucleotideSequence, surface: BindingSurface): Sequence<BindingSite> {
+        if (pattern.isEmpty()) {
+            return sequenceOf(surface.site(0, 0))
+        }
+
+        if (pattern.size > surface.length) {
+            return emptySequence()
+        }
+
+        val lastStartIndex = surface.length - pattern.size
+        return sequence {
+            for (startIndex in 0..lastStartIndex) {
+                var matches = true
+
+                for (offset in 0 until pattern.size) {
+                    if (pattern[offset] != surface.sequence[startIndex + offset].complement()) {
+                        matches = false
+                        break
+                    }
+                }
+
+                if (matches) {
+                    yield(BindingSite(surface, SequenceRange(startIndex, startIndex + pattern.size)))
+                }
+            }
         }
     }
 }
-

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -21,37 +21,34 @@ object ProteinBinding {
         target: BindingSurface,
         registry: BondRegistry,
     ): Bond? {
-        val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)
-            ?: return null
-
         val normalizedStrength = binder.affinity.coerceIn(0.0, 1.0)
         if (normalizedStrength <= 0.0) {
             return null
         }
 
-        val overlapping = registry.overlapping(targetSite)
-        val strongestOverlap = overlapping.maxOfOrNull(Bond::strength)
-        val conflictThreshold = if (normalizedStrength > CONFLICT_EPSILON) {
-            normalizedStrength - CONFLICT_EPSILON
-        } else {
-            normalizedStrength
+        val conflictThreshold = if (normalizedStrength > CONFLICT_EPSILON) normalizedStrength - CONFLICT_EPSILON else normalizedStrength
+
+        for (targetSite in BindingMatcher.complementaryMatchSites(binder.bindingPattern, target)) {
+            val overlapping = registry.overlapping(targetSite)
+            val strongestOverlap = overlapping.maxOfOrNull(Bond::strength)
+
+            if (strongestOverlap != null && strongestOverlap >= conflictThreshold) {
+                continue
+            }
+
+            overlapping.forEach(registry::remove)
+
+            val bond = Bond(
+                left = WholeMoleculeEndpoint(proteinId),
+                right = SiteEndpoint(targetSite),
+                strength = normalizedStrength,
+                decayPerTick = DEFAULT_DECAY_PER_TICK,
+            )
+
+            registry.add(bond)
+            return bond
         }
 
-        if (strongestOverlap != null && strongestOverlap >= conflictThreshold) {
-            return null
-        }
-
-        overlapping.forEach(registry::remove)
-
-        val bond = Bond(
-            left = WholeMoleculeEndpoint(proteinId),
-            right = SiteEndpoint(targetSite),
-            strength = normalizedStrength,
-            decayPerTick = DEFAULT_DECAY_PER_TICK,
-        )
-
-        registry.add(bond)
-
-        return bond
+        return null
     }
 }

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BindingMatcherTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BindingMatcherTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class BindingMatcherTest {
     @Test
@@ -41,5 +42,19 @@ class BindingMatcherTest {
 
         assertNull(BindingMatcher.complementaryMatchSite(NucleotideSequence.of("ACG"), surface))
     }
-}
 
+    @Test
+    fun `complementary match sites yields sites in deterministic left to right order`() {
+        val pattern = NucleotideSequence.of("AUG")
+        val surface = MRna.of("GGUACUACAA").bindingSurface(MoleculeId(9))
+
+        val sites = BindingMatcher.complementaryMatchSites(pattern, surface).toList()
+
+        assertEquals(2, sites.size)
+        assertEquals(2, sites[0].range.start)
+        assertEquals(5, sites[0].range.endExclusive)
+        assertEquals(5, sites[1].range.start)
+        assertEquals(8, sites[1].range.endExclusive)
+        assertTrue(sites[0].range.start < sites[1].range.start)
+    }
+}

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -260,6 +260,131 @@ class ProteinBindingTest {
         assertEquals(listOf(bond), registry.toList())
     }
 
+    @Test
+    fun `tryBind skips first blocked matching site and binds at second viable site`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.7)
+        val target = MRna.of("AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG")
+            .bindingSurface(MoleculeId(560))
+        val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
+        val blockedFirst = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(561)),
+            right = SiteEndpoint(matchingSites.first()),
+            strength = 0.9,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(blockedFirst))
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(562),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNotNull(bond)
+        assertEquals(matchingSites[1], (bond.right as SiteEndpoint).site)
+        assertTrue(registry.toList().contains(blockedFirst))
+        assertTrue(registry.toList().contains(bond))
+    }
+
+    @Test
+    fun `tryBind skips multiple blocked matching sites and binds at later viable site`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.7)
+        val target = MRna.of(
+            "AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG${asText(binder.bindingPattern.complement())}UU",
+        ).bindingSurface(MoleculeId(570))
+        val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
+        val blockedFirst = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(571)),
+            right = SiteEndpoint(matchingSites[0]),
+            strength = 0.8,
+            decayPerTick = 0.05,
+        )
+        val blockedSecond = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(572)),
+            right = SiteEndpoint(matchingSites[1]),
+            strength = 0.9,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(blockedFirst, blockedSecond))
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(573),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNotNull(bond)
+        assertEquals(matchingSites[2], (bond.right as SiteEndpoint).site)
+        assertEquals(3, registry.size)
+    }
+
+    @Test
+    fun `tryBind returns null when all matching sites are blocked by equal or stronger overlaps`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.7)
+        val target = MRna.of("AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG")
+            .bindingSurface(MoleculeId(580))
+        val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
+        val blockedFirst = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(581)),
+            right = SiteEndpoint(matchingSites[0]),
+            strength = 0.7,
+            decayPerTick = 0.05,
+        )
+        val blockedSecond = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(582)),
+            right = SiteEndpoint(matchingSites[1]),
+            strength = 0.95,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(blockedFirst, blockedSecond))
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(583),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNull(bond)
+        assertEquals(listOf(blockedFirst, blockedSecond), registry.toList())
+    }
+
+    @Test
+    fun `tryBind displaces weaker overlap at later viable site while scanning`() {
+        val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.8)
+        val target = MRna.of("AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG")
+            .bindingSurface(MoleculeId(590))
+        val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
+        val strongFirst = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(591)),
+            right = SiteEndpoint(matchingSites[0]),
+            strength = 0.9,
+            decayPerTick = 0.05,
+        )
+        val weakSecond = Bond(
+            left = WholeMoleculeEndpoint(MoleculeId(592)),
+            right = SiteEndpoint(matchingSites[1]),
+            strength = 0.3,
+            decayPerTick = 0.05,
+        )
+        val registry = BondRegistry(listOf(strongFirst, weakSecond))
+
+        val bond = ProteinBinding.tryBind(
+            proteinId = MoleculeId(593),
+            binder = binder,
+            target = target,
+            registry = registry,
+        )
+
+        assertNotNull(bond)
+        assertEquals(matchingSites[1], (bond.right as SiteEndpoint).site)
+        assertEquals(2, registry.size)
+        assertTrue(registry.toList().contains(strongFirst))
+        assertTrue(registry.toList().contains(bond))
+    }
+
     private fun interpretedBinderFrom(sequence: String): SequenceBinder {
         val domain = ProteinInterpreter.interpret(Polypeptide.of(sequence)).single()
         return domain.capabilities.single() as SequenceBinder

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -214,17 +214,17 @@ classDiagram
 ```mermaid
 flowchart LR
     A[SequenceBinder.bindingPattern] --> B[BindingMatcher]
-    B --> C{Complementary match found?}
+    B --> C{Any complementary match sites?}
     C -- No --> D[Return null]
-    C -- Yes --> E[Create SequenceRange]
-    E --> F[Create BindingSite on target surface]
-    F --> G{Affinity > 0?}
-    G -- No --> H[Return null]
-    G -- Yes --> I{Stronger/equal overlap exists?}
-    I -- Yes --> J[Return null]
-    I -- No --> K[Remove weaker overlapping bonds]
-    K --> L[Create and store Bond]
-    L --> M[Return Bond]
+    C -- Yes --> E[Iterate sites left to right]
+    E --> F{Affinity > 0?}
+    F -- No --> G[Return null]
+    F -- Yes --> H{Stronger/equal overlap exists at current site?}
+    H -- Yes --> I[Skip site, continue scan]
+    H -- No --> J[Remove weaker overlapping bonds at site]
+    J --> K[Create and store Bond]
+    K --> L[Return Bond]
+    I --> E
 ```
 
 ---
@@ -235,12 +235,12 @@ flowchart LR
 
 The return contract is:
 
-- returns a `Bond` when matching succeeds and occupancy checks pass
-- returns `null` when there is no complementary site, the affinity normalizes to inactive (`<= 0`), or an equal/stronger overlapping bond occupies the region
+- returns a `Bond` at the first viable complementary site (deterministic left-to-right scan)
+- returns `null` when there is no complementary site, affinity normalizes to inactive (`<= 0`), or all matching sites are blocked by equal/stronger overlaps
 
 Conflict resolution still happens inside `ProteinBinding` by mutating `BondRegistry`:
 
-- weaker overlapping bonds are removed before creating a stronger replacement bond
+- weaker overlapping bonds are removed at the chosen viable site before creating a stronger replacement bond
 - callers can validate side effects by inspecting registry state rather than consuming a displaced-bonds payload
 
 ---


### PR DESCRIPTION
### Motivation

- `ProteinBinding.tryBind(...)` previously bound only to the first complementary match returned by the matcher, causing bind attempts to fail prematurely when that first match was occupied by an equal/stronger overlap even though a later match was viable.
- The change enables sequence-driven binders to continue scanning a target surface and bind to the first viable complementary site following deterministic left-to-right ordering.

### Description

- Added `BindingMatcher.complementaryMatchSites(pattern, surface)` which yields all complementary `BindingSite` candidates in deterministic left-to-right order and made `complementaryMatchSite(...)` delegate to it.
- Updated `ProteinBinding.tryBind(...)` to iterate candidate sites from `complementaryMatchSites(...)`, skip sites blocked by equal/stronger overlaps, displace weaker overlaps only at the chosen viable site, and return the created `Bond` for the first viable site or `null` if none exists.
- Preserved the existing conflict threshold and displacement semantics (including the small epsilon rule) when evaluating each candidate site.
- Added unit tests covering deterministic candidate ordering, skipping blocked first/multiple sites, returning `null` when all sites are blocked, displacing weaker occupants at later sites, and updated docs to describe the scan-then-bind flow and revised return contract.

### Testing

- Ran the focused biology tests for the matcher and binding logic with `./gradlew :biology:test --tests 'life.sim.biology.interactions.BindingMatcherTest' --tests 'life.sim.biology.proteins.ProteinBindingTest'` and the run completed successfully (tests passed).
- All added and existing tests exercised the new matching and binding behavior and passed in the focused test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea74a3c35c8329ad3783ac8a2c43a3)