### PR TITLE
Add ActiveProtein runtime molecule with constructors, tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ The repository currently has a strong **biology foundation** and an early
   (DNA/RNA-like polymers, amino acids, polypeptides).
 * **Interaction mechanics are implemented**
   (binding sites/surfaces/strands, bonds, matcher, bond registry).
-* **Protein interpretation has started**
-  with motif/domain-capability mapping in `ProteinInterpreter`.
+* **Protein interpretation is modeled at runtime**
+  with motif/domain-capability mapping in `ProteinInterpreter` and
+  first-class `ActiveProtein` molecules that preserve interpreted output.
 * **Simulator module exists**
   but still contains placeholder/demo-level behavior compared with biology.
 

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
@@ -14,7 +14,8 @@ data class ActiveProtein private constructor(
     val source: Polypeptide,
     val domains: List<ProteinDomain>,
 ) {
-    val capabilities: List<MolecularCapability> = domains.flatMap(ProteinDomain::capabilities)
+    val capabilities: List<MolecularCapability> =
+        Collections.unmodifiableList(domains.flatMap(ProteinDomain::capabilities))
 
     companion object {
         /**

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
@@ -1,0 +1,42 @@
+package life.sim.biology.proteins
+
+import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.molecules.Polypeptide
+
+/**
+ * First-class runtime protein molecule with stable identity and preserved interpretation output.
+ */
+data class ActiveProtein(
+    val moleculeId: MoleculeId,
+    val source: Polypeptide,
+    val domains: List<ProteinDomain>,
+    val capabilities: List<MolecularCapability>,
+) {
+    companion object {
+        /**
+         * Creates an [ActiveProtein] from already interpreted [domains] and flattens capability access.
+         */
+        fun fromDomains(
+            moleculeId: MoleculeId,
+            source: Polypeptide,
+            domains: List<ProteinDomain>,
+        ): ActiveProtein = ActiveProtein(
+            moleculeId = moleculeId,
+            source = source,
+            domains = domains,
+            capabilities = domains.flatMap(ProteinDomain::capabilities),
+        )
+
+        /**
+         * Interprets [source] and returns a first-class runtime protein molecule.
+         */
+        fun interpret(
+            moleculeId: MoleculeId,
+            source: Polypeptide,
+        ): ActiveProtein = fromDomains(
+            moleculeId = moleculeId,
+            source = source,
+            domains = ProteinInterpreter.interpret(source),
+        )
+    }
+}

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
@@ -2,16 +2,19 @@ package life.sim.biology.proteins
 
 import life.sim.biology.interactions.MoleculeId
 import life.sim.biology.molecules.Polypeptide
+import kotlin.ConsistentCopyVisibility
 
 /**
  * First-class runtime protein molecule with stable identity and preserved interpretation output.
  */
-data class ActiveProtein(
+@ConsistentCopyVisibility
+data class ActiveProtein private constructor(
     val moleculeId: MoleculeId,
     val source: Polypeptide,
     val domains: List<ProteinDomain>,
-    val capabilities: List<MolecularCapability>,
 ) {
+    val capabilities: List<MolecularCapability> = domains.flatMap(ProteinDomain::capabilities)
+
     companion object {
         /**
          * Creates an [ActiveProtein] from already interpreted [domains] and flattens capability access.
@@ -21,13 +24,14 @@ data class ActiveProtein(
             source: Polypeptide,
             domains: List<ProteinDomain>,
         ): ActiveProtein {
-            val immutableDomains = domains.toList()
+            val immutableDomains = domains.map { domain ->
+                domain.copy(capabilities = domain.capabilities.toList())
+            }
 
             return ActiveProtein(
                 moleculeId = moleculeId,
                 source = source,
                 domains = immutableDomains,
-                capabilities = immutableDomains.flatMap(ProteinDomain::capabilities),
             )
         }
 

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
@@ -2,6 +2,7 @@ package life.sim.biology.proteins
 
 import life.sim.biology.interactions.MoleculeId
 import life.sim.biology.molecules.Polypeptide
+import java.util.Collections
 import kotlin.ConsistentCopyVisibility
 
 /**
@@ -24,9 +25,13 @@ data class ActiveProtein private constructor(
             source: Polypeptide,
             domains: List<ProteinDomain>,
         ): ActiveProtein {
-            val immutableDomains = domains.map { domain ->
-                domain.copy(capabilities = domain.capabilities.toList())
-            }
+            val immutableDomains = Collections.unmodifiableList(
+                domains.map { domain ->
+                    domain.copy(
+                        capabilities = Collections.unmodifiableList(domain.capabilities.toList()),
+                    )
+                },
+            )
 
             return ActiveProtein(
                 moleculeId = moleculeId,

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
@@ -20,12 +20,16 @@ data class ActiveProtein(
             moleculeId: MoleculeId,
             source: Polypeptide,
             domains: List<ProteinDomain>,
-        ): ActiveProtein = ActiveProtein(
-            moleculeId = moleculeId,
-            source = source,
-            domains = domains,
-            capabilities = domains.flatMap(ProteinDomain::capabilities),
-        )
+        ): ActiveProtein {
+            val immutableDomains = domains.toList()
+
+            return ActiveProtein(
+                moleculeId = moleculeId,
+                source = source,
+                domains = immutableDomains,
+                capabilities = immutableDomains.flatMap(ProteinDomain::capabilities),
+            )
+        }
 
         /**
          * Interprets [source] and returns a first-class runtime protein molecule.

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
@@ -6,6 +6,7 @@ import life.sim.biology.primitives.NucleotideSequence
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotSame
 
 class ActiveProteinTest {
@@ -135,6 +136,54 @@ class ActiveProteinTest {
 
         assertNotSame(mutableCapabilities, activeProtein.domains.single().capabilities)
         assertEquals(1, activeProtein.domains.single().capabilities.size)
+        assertEquals(
+            activeProtein.domains.flatMap(ProteinDomain::capabilities),
+            activeProtein.capabilities,
+        )
+    }
+
+    @Test
+    fun `fromDomains exposes unmodifiable domain and capability lists`() {
+        val source = Polypeptide.of("AAKRGKTTHEMH")
+        val activeProtein = ActiveProtein.fromDomains(
+            moleculeId = MoleculeId(99),
+            source = source,
+            domains = listOf(
+                ProteinDomain(
+                    name = "BinderDomain",
+                    startInclusive = 2,
+                    endExclusive = 6,
+                    motif = "KRGK",
+                    capabilities = listOf(
+                        SequenceBinder(
+                            bindingPattern = NucleotideSequence.of("ACGUAC"),
+                            affinity = 0.7,
+                            specificity = 0.4,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val exposedDomains = activeProtein.domains as MutableList<ProteinDomain>
+        assertFailsWith<UnsupportedOperationException> {
+            exposedDomains.add(
+                ProteinDomain(
+                    name = "CutterDomain",
+                    startInclusive = 8,
+                    endExclusive = 12,
+                    motif = "HEMH",
+                    capabilities = listOf(Cutter(catalyticStrength = 0.8)),
+                ),
+            )
+        }
+
+        val exposedCapabilities = activeProtein.domains.single().capabilities as MutableList<MolecularCapability>
+        assertFailsWith<UnsupportedOperationException> {
+            exposedCapabilities.add(Cutter(catalyticStrength = 0.6))
+        }
+
+        assertEquals(1, activeProtein.domains.size)
         assertEquals(
             activeProtein.domains.flatMap(ProteinDomain::capabilities),
             activeProtein.capabilities,

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
@@ -6,6 +6,7 @@ import life.sim.biology.primitives.NucleotideSequence
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
 
 class ActiveProteinTest {
     @Test
@@ -59,5 +60,48 @@ class ActiveProteinTest {
         assertEquals(source, activeProtein.source)
         assertEquals(ProteinInterpreter.interpret(source), activeProtein.domains)
         assertEquals(activeProtein.domains.flatMap(ProteinDomain::capabilities), activeProtein.capabilities)
+    }
+
+    @Test
+    fun `fromDomains copies input domain list to keep domains and capabilities consistent`() {
+        val source = Polypeptide.of("AAKRGKTTHEMH")
+        val mutableDomains = mutableListOf(
+            ProteinDomain(
+                name = "BinderDomain",
+                startInclusive = 2,
+                endExclusive = 6,
+                motif = "KRGK",
+                capabilities = listOf(
+                    SequenceBinder(
+                        bindingPattern = NucleotideSequence.of("ACGUAC"),
+                        affinity = 0.7,
+                        specificity = 0.4,
+                    ),
+                ),
+            ),
+        )
+
+        val activeProtein = ActiveProtein.fromDomains(
+            moleculeId = MoleculeId(77),
+            source = source,
+            domains = mutableDomains,
+        )
+
+        mutableDomains.add(
+            ProteinDomain(
+                name = "CutterDomain",
+                startInclusive = 8,
+                endExclusive = 12,
+                motif = "HEMH",
+                capabilities = listOf(Cutter(catalyticStrength = 0.8)),
+            ),
+        )
+
+        assertNotSame(mutableDomains, activeProtein.domains)
+        assertEquals(1, activeProtein.domains.size)
+        assertEquals(
+            activeProtein.domains.flatMap(ProteinDomain::capabilities),
+            activeProtein.capabilities,
+        )
     }
 }

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
@@ -183,6 +183,11 @@ class ActiveProteinTest {
             exposedCapabilities.add(Cutter(catalyticStrength = 0.6))
         }
 
+        val flattenedCapabilities = activeProtein.capabilities as MutableList<MolecularCapability>
+        assertFailsWith<UnsupportedOperationException> {
+            flattenedCapabilities.add(Cutter(catalyticStrength = 0.5))
+        }
+
         assertEquals(1, activeProtein.domains.size)
         assertEquals(
             activeProtein.domains.flatMap(ProteinDomain::capabilities),

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
@@ -104,4 +104,40 @@ class ActiveProteinTest {
             activeProtein.capabilities,
         )
     }
+
+    @Test
+    fun `fromDomains copies domain capability lists to keep flattened capabilities consistent`() {
+        val source = Polypeptide.of("AAKRGKTTHEMH")
+        val mutableCapabilities = mutableListOf<MolecularCapability>(
+            SequenceBinder(
+                bindingPattern = NucleotideSequence.of("ACGUAC"),
+                affinity = 0.7,
+                specificity = 0.4,
+            ),
+        )
+        val mutableDomains = listOf(
+            ProteinDomain(
+                name = "BinderDomain",
+                startInclusive = 2,
+                endExclusive = 6,
+                motif = "KRGK",
+                capabilities = mutableCapabilities,
+            ),
+        )
+
+        val activeProtein = ActiveProtein.fromDomains(
+            moleculeId = MoleculeId(88),
+            source = source,
+            domains = mutableDomains,
+        )
+
+        mutableCapabilities.add(Cutter(catalyticStrength = 0.8))
+
+        assertNotSame(mutableCapabilities, activeProtein.domains.single().capabilities)
+        assertEquals(1, activeProtein.domains.single().capabilities.size)
+        assertEquals(
+            activeProtein.domains.flatMap(ProteinDomain::capabilities),
+            activeProtein.capabilities,
+        )
+    }
 }

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
@@ -1,0 +1,63 @@
+package life.sim.biology.proteins
+
+import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.molecules.Polypeptide
+import life.sim.biology.primitives.NucleotideSequence
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ActiveProteinTest {
+    @Test
+    fun `fromDomains keeps molecule id source and interpreted domains while flattening capabilities`() {
+        val source = Polypeptide.of("AAKRGKTTHEMH")
+        val domains = listOf(
+            ProteinDomain(
+                name = "BinderDomain",
+                startInclusive = 2,
+                endExclusive = 6,
+                motif = "KRGK",
+                capabilities = listOf(
+                    SequenceBinder(
+                        bindingPattern = NucleotideSequence.of("ACGUAC"),
+                        affinity = 0.7,
+                        specificity = 0.4,
+                    ),
+                ),
+            ),
+            ProteinDomain(
+                name = "CutterDomain",
+                startInclusive = 8,
+                endExclusive = 12,
+                motif = "HEMH",
+                capabilities = listOf(Cutter(catalyticStrength = 0.8)),
+            ),
+        )
+
+        val activeProtein = ActiveProtein.fromDomains(
+            moleculeId = MoleculeId(42),
+            source = source,
+            domains = domains,
+        )
+
+        assertEquals(MoleculeId(42), activeProtein.moleculeId)
+        assertEquals(source, activeProtein.source)
+        assertEquals(domains, activeProtein.domains)
+        assertEquals(domains.flatMap(ProteinDomain::capabilities), activeProtein.capabilities)
+    }
+
+    @Test
+    fun `interpret preserves interpreter output and derived flattened capabilities`() {
+        val source = Polypeptide.of("AAKRGKTTHEMHPPW")
+
+        val activeProtein = ActiveProtein.interpret(
+            moleculeId = MoleculeId(9),
+            source = source,
+        )
+
+        assertEquals(MoleculeId(9), activeProtein.moleculeId)
+        assertEquals(source, activeProtein.source)
+        assertEquals(ProteinInterpreter.interpret(source), activeProtein.domains)
+        assertEquals(activeProtein.domains.flatMap(ProteinDomain::capabilities), activeProtein.capabilities)
+    }
+}

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -15,6 +15,7 @@ Current molecule types:
 - `MRna` — messenger RNA wrapper
 - `TRna` — transfer RNA wrapper with complementary scanning support
 - `Polypeptide` — translated amino-acid chain used as input to protein-domain interpretation
+- `ActiveProtein` — runtime protein molecule with stable `MoleculeId`, source chain, and interpreted protein outputs
 
 Nucleotide-based molecule types (`Dna`, `MRna`, and `TRna`) use the shared RNA alphabet (`A`, `C`, `G`, `U`), while `Polypeptide` uses the amino-acid alphabet.
 
@@ -115,11 +116,18 @@ A `Polypeptide` can be passed into `ProteinInterpreter` (in `life.sim.biology.pr
 The interpreter scans motif patterns and emits one or more `ProteinDomain`s, each of which exposes
 `MolecularCapability` values such as `SequenceBinder`, `Cutter`, `Ligase`, or `Blocker`.
 
-`SequenceBinder` capabilities now include a derived nucleotide `bindingPattern`, so interpreted binders
+`SequenceBinder` capabilities include a derived nucleotide `bindingPattern`, so interpreted binders
 carry concrete sequence targets that can be used during runtime matching.
 
-This keeps sequence storage separate from interpreted function and supports composing multiple
-capabilities from a single chain.
+When a protein needs to exist as an explicit runtime molecule, `ActiveProtein` can be created with:
+
+- `moleculeId: MoleculeId` (stable runtime identity)
+- `source: Polypeptide` (the source amino-acid chain)
+- `domains: List<ProteinDomain>` (preserved interpreted domains)
+- `capabilities: List<MolecularCapability>` (flattened capabilities derived from `domains`)
+
+This keeps sequence storage separate from interpreted function while still allowing runtime code
+to pass a first-class protein molecule value instead of carrying temporary tuples.
 
 ---
 
@@ -131,6 +139,8 @@ Runtime occupancy and binding state are modeled separately by the interactions l
 
 The `ProteinBinding.tryBind(...)` helper bridges interpretation to runtime associations by using a
 `SequenceBinder` pattern plus `BindingMatcher` to create and register concrete `Bond` values.
+`ActiveProtein` complements this by preserving interpreted domains/capabilities alongside the
+protein's stable runtime `MoleculeId`.
 
 That separation allows molecule values to remain immutable while runtime systems track transient binding dynamics.
 

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -18,7 +18,7 @@ Current molecule types:
 
 Nucleotide-based molecule types (`Dna`, `MRna`, and `TRna`) use the shared RNA alphabet (`A`, `C`, `G`, `U`), while `Polypeptide` uses the amino-acid alphabet.
 
-Related protein-runtime types such as `ActiveProtein` live in `life.sim.biology.proteins` and are referenced here only when describing interpretation flow.
+Related protein-runtime types such as `ActiveProtein` live in `life.sim.biology.proteins` and are referenced here only when describing interpretation flow. See [`docs/biology/proteins.md`](./proteins.md) for protein-package details.
 
 ---
 

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -15,9 +15,10 @@ Current molecule types:
 - `MRna` — messenger RNA wrapper
 - `TRna` — transfer RNA wrapper with complementary scanning support
 - `Polypeptide` — translated amino-acid chain used as input to protein-domain interpretation
-- `ActiveProtein` — runtime protein molecule with stable `MoleculeId`, source chain, and interpreted protein outputs
 
 Nucleotide-based molecule types (`Dna`, `MRna`, and `TRna`) use the shared RNA alphabet (`A`, `C`, `G`, `U`), while `Polypeptide` uses the amino-acid alphabet.
+
+Related protein-runtime types such as `ActiveProtein` live in `life.sim.biology.proteins` and are referenced here only when describing interpretation flow.
 
 ---
 

--- a/docs/biology/proteins.md
+++ b/docs/biology/proteins.md
@@ -1,0 +1,103 @@
+# Proteins
+
+This document describes the protein-layer types in `life.sim.biology.proteins`.
+
+These types interpret `Polypeptide` sequences into runtime domain/capability values and bridge those capabilities into interaction-state changes.
+
+---
+
+## Overview
+
+Protein-package types:
+
+- `ProteinInterpreter` — maps `Polypeptide` motifs to interpreted `ProteinDomain` hits
+- `ProteinDomain` — one interpreted motif hit with source span and capabilities
+- `MolecularCapability` — sealed runtime capability model (`SequenceBinder`, `Cutter`, `Ligase`, `Blocker`)
+- `ActiveProtein` — first-class runtime protein value with stable `MoleculeId`, source chain, interpreted domains, and flattened capabilities
+- `ProteinBinding` — helper that turns `SequenceBinder` capabilities into concrete `Bond` associations
+
+---
+
+## `ProteinInterpreter`
+
+`ProteinInterpreter.interpret(polypeptide)` scans a `Polypeptide` for known motifs and emits sorted `ProteinDomain` values.
+
+Current behavior:
+
+- each motif hit becomes a `ProteinDomain` with:
+  - `name`
+  - `startInclusive`
+  - `endExclusive`
+  - `motif`
+  - `capabilities`
+- domains are sorted by `(startInclusive, name)` for deterministic output
+- an empty polypeptide yields no domains
+
+The interpreter currently emits one capability per domain and derives binder target sequences via a deterministic pattern-generation step over local residue context.
+
+---
+
+## `ProteinDomain`
+
+`ProteinDomain` is an immutable description of one interpreted region in a source `Polypeptide`.
+
+It keeps both:
+
+- structural metadata (`name`, motif span, motif text)
+- behavior metadata (`capabilities`)
+
+Because capabilities are carried on the domain itself, higher-level code can preserve interpretation output directly rather than re-deriving behavior later.
+
+---
+
+## `MolecularCapability`
+
+`MolecularCapability` is a sealed interface for runtime behavior tags and parameters.
+
+Current capability data classes:
+
+- `SequenceBinder(bindingPattern, affinity, specificity)`
+- `Cutter(catalyticStrength)`
+- `Ligase(catalyticStrength)`
+- `Blocker(potency)`
+
+Each capability also exposes a string `kind` value for lightweight runtime classification.
+
+---
+
+## `ActiveProtein`
+
+`ActiveProtein` is the runtime protein aggregate:
+
+- `moleculeId: MoleculeId`
+- `source: Polypeptide`
+- `domains: List<ProteinDomain>`
+- `capabilities: List<MolecularCapability>`
+
+Construction helpers:
+
+- `ActiveProtein.fromDomains(...)` for already interpreted domains
+- `ActiveProtein.interpret(...)` to interpret a source chain and build the runtime object in one step
+
+Use `ActiveProtein` when runtime systems need a first-class protein identity/value rather than passing around temporary tuples.
+
+---
+
+## `ProteinBinding`
+
+`ProteinBinding.tryBind(...)` bridges interpreted binders into interactions by:
+
+1. normalizing binder affinity into bond strength
+2. scanning complementary match sites via `BindingMatcher`
+3. resolving overlap conflicts through `BondRegistry`
+4. creating/storing a `Bond` from protein (`WholeMoleculeEndpoint`) to target site (`SiteEndpoint`)
+
+This keeps molecule/protein values immutable while runtime occupancy and conflicts stay in the interactions layer.
+
+---
+
+## Relationship to molecule docs
+
+`docs/biology/molecules.md` covers molecule wrappers (`Dna`, `MRna`, `TRna`, `Polypeptide`) and references protein concepts only where needed for cross-layer flow.
+
+For protein-package details, use this document as the primary reference.


### PR DESCRIPTION
### Motivation

- Introduce a first-class runtime protein value so interpreted proteins carry stable identity and preserved interpretation results instead of being ad-hoc tuples. 

### Description

- Add immutable `ActiveProtein` data class in `life.sim.biology.proteins` with `moleculeId: MoleculeId`, `source: Polypeptide`, `domains: List<ProteinDomain>`, and `capabilities: List<MolecularCapability>`.
- Provide construction helpers `ActiveProtein.fromDomains(...)` and `ActiveProtein.interpret(...)` which flatten domain capabilities and/or invoke `ProteinInterpreter` as needed.
- Add unit tests `ActiveProteinTest` that assert `fromDomains(...)` preserves id/source/domains and flattens capabilities and that `interpret(...)` preserves interpreter output and derived capabilities.
- Update documentation in `README.md` and `docs/biology/molecules.md` to document `ActiveProtein` and how it relates to `Polypeptide`, `ProteinInterpreter`, and the interactions model.

### Testing

- Ran `./gradlew :biology:test`, which completed successfully (build and biology tests passed). 
- The new `ActiveProteinTest` cases executed and passed as part of the biology test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6c68778483299374e4f968c6ee50)