### PR TITLE
Replace tileSize with baseSize in NucleotideRenderer and update geometry bounds tests

### DIFF
--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/MoleculeRenderers.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/MoleculeRenderers.kt
@@ -12,9 +12,9 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 class NucleotideRenderer(
-    val tileSize: Float = 34f,
+    val baseSize: Float = 34f,
 ) : Renderer<Nucleotide> {
-    private val pairingBandSize = tileSize * 0.5f
+    private val pairingBandSize = baseSize * 0.5f
 
     init {
         Renderers.register(Nucleotide::class, this)
@@ -50,7 +50,7 @@ class NucleotideRenderer(
             context.drawLine(line.a, line.b, line.width, color)
         }
 
-        context.drawCenteredText(value.symbol.toString(), position.x + tileSize * 0.5f, position.y + tileSize * 0.5f)
+        context.drawCenteredText(value.symbol.toString(), position.x + baseSize * 0.5f, position.y + baseSize * 0.5f)
     }
 
     internal fun connectorProfile(nucleotide: Nucleotide): ConnectorProfile = when (nucleotide) {
@@ -83,20 +83,20 @@ class NucleotideRenderer(
         when (profile.family) {
             ConnectorFamily.ANGLED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
-                    filledRects += Rect(position.x, position.y, tileSize, tileSize)
+                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
                     filledTriangles += triangleOnSide(position, orientation.pairingSide)
                 } else {
-                    filledRects += Rect(position.x, position.y, tileSize, tileSize)
+                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
                     filledTriangles += inverseTriangleOnSide(position, orientation.pairingSide)
                 }
             }
 
             ConnectorFamily.ROUNDED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
-                    filledRects += Rect(position.x, position.y, tileSize, tileSize)
+                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
                     filledArcs += roundedOnSide(position, orientation.pairingSide)
                 } else {
-                    filledRects += Rect(position.x, position.y, tileSize, tileSize)
+                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
                     arcs += roundedSocketOnSide(position, orientation.pairingSide)
                 }
             }
@@ -110,68 +110,6 @@ class NucleotideRenderer(
             triangles = triangles,
             lines = lines,
         )
-    }
-
-    internal fun boundsWithinTile(geometry: NucleotideGeometry, position: Vector2): Boolean {
-        val minX = position.x - tileSize * 0.75f
-        val maxX = position.x + tileSize * 1.75f
-        val minY = position.y - tileSize * 0.75f
-        val maxY = position.y + tileSize * 1.75f
-
-        val rectsInBounds = geometry.filledRects.all { rect ->
-            rect.x >= minX &&
-                rect.y >= minY &&
-                rect.x + rect.width <= maxX &&
-                rect.y + rect.height <= maxY
-        }
-
-        if (!rectsInBounds) {
-            return false
-        }
-
-        val filledTrianglesInBounds = geometry.filledTriangles.all { triangle ->
-            val xs = listOf(triangle.x1, triangle.x2, triangle.x3)
-            val ys = listOf(triangle.y1, triangle.y2, triangle.y3)
-            xs.all { it in minX..maxX } && ys.all { it in minY..maxY }
-        }
-
-        if (!filledTrianglesInBounds) {
-            return false
-        }
-
-        val trianglesInBounds = geometry.triangles.all { triangle ->
-            val xs = listOf(triangle.x1, triangle.x2, triangle.x3)
-            val ys = listOf(triangle.y1, triangle.y2, triangle.y3)
-            xs.all { it in minX..maxX } && ys.all { it in minY..maxY }
-        }
-
-        if (!trianglesInBounds) {
-            return false
-        }
-
-        val filledArcsInBounds = geometry.filledArcs.all { arc ->
-            arcBounds(arc, includeCenter = true).isWithin(minX, maxX, minY, maxY)
-        }
-
-        if (!filledArcsInBounds) {
-            return false
-        }
-
-        val arcsInBounds = geometry.arcs.all { arc ->
-            arcBounds(arc).isWithin(minX, maxX, minY, maxY)
-        }
-
-        if (!arcsInBounds) {
-            return false
-        }
-
-        val linesInBounds = geometry.lines.all { line ->
-            listOf(line.a, line.b).all { point ->
-                point.x in minX..maxX && point.y in minY..maxY
-            }
-        }
-
-        return linesInBounds
     }
 
     internal fun arcBounds(arc: Arc, includeCenter: Boolean = false): ShapeBounds {
@@ -261,51 +199,51 @@ class NucleotideRenderer(
             PairingSide.TOP -> listOf(
                 Triangle(
                     x,
-                    y + tileSize,
+                    y + baseSize,
                     x,
-                    y + tileSize + pairingBandSize,
-                    x + tileSize * 0.5f,
-                    y + tileSize,
+                    y + baseSize + pairingBandSize,
+                    x + baseSize * 0.5f,
+                    y + baseSize,
                 ),
                 Triangle(
-                    x + tileSize * 0.5f,
-                    y + tileSize,
-                    x + tileSize,
-                    y + tileSize + pairingBandSize,
-                    x + tileSize,
-                    y + tileSize,
+                    x + baseSize * 0.5f,
+                    y + baseSize,
+                    x + baseSize,
+                    y + baseSize + pairingBandSize,
+                    x + baseSize,
+                    y + baseSize,
                 ),
             )
             PairingSide.BOTTOM -> listOf(
                 Triangle(
                     x,
                     y,
-                    x + tileSize * 0.5f,
+                    x + baseSize * 0.5f,
                     y,
                     x,
                     y - pairingBandSize,
                 ),
                 Triangle(
-                    x + tileSize * 0.5f,
+                    x + baseSize * 0.5f,
                     y,
-                    x + tileSize,
+                    x + baseSize,
                     y,
-                    x + tileSize,
+                    x + baseSize,
                     y - pairingBandSize,
                 ),
             )
             PairingSide.LEFT -> listOf(
                 Triangle(
                     x,
-                    y + tileSize,
+                    y + baseSize,
                     x,
-                    y + tileSize * 0.5f,
+                    y + baseSize * 0.5f,
                     x - pairingBandSize,
-                    y + tileSize,
+                    y + baseSize,
                 ),
                 Triangle(
                     x,
-                    y + tileSize * 0.5f,
+                    y + baseSize * 0.5f,
                     x,
                     y,
                     x - pairingBandSize,
@@ -314,19 +252,19 @@ class NucleotideRenderer(
             )
             PairingSide.RIGHT -> listOf(
                 Triangle(
-                    x + tileSize,
-                    y + tileSize,
-                    x + tileSize + pairingBandSize,
-                    y + tileSize,
-                    x + tileSize,
-                    y + tileSize * 0.5f,
+                    x + baseSize,
+                    y + baseSize,
+                    x + baseSize + pairingBandSize,
+                    y + baseSize,
+                    x + baseSize,
+                    y + baseSize * 0.5f,
                 ),
                 Triangle(
-                    x + tileSize,
-                    y + tileSize * 0.5f,
-                    x + tileSize + pairingBandSize,
+                    x + baseSize,
+                    y + baseSize * 0.5f,
+                    x + baseSize + pairingBandSize,
                     y,
-                    x + tileSize,
+                    x + baseSize,
                     y,
                 ),
             )
@@ -341,32 +279,32 @@ class NucleotideRenderer(
                 x,
                 y,
                 x,
-                y + tileSize,
+                y + baseSize,
                 x - pairingBandSize,
-                y + tileSize * 0.5f,
+                y + baseSize * 0.5f,
             )
             PairingSide.RIGHT -> Triangle(
-                x + tileSize,
+                x + baseSize,
                 y,
-                x + tileSize + pairingBandSize,
-                y + tileSize * 0.5f,
-                x + tileSize,
-                y + tileSize,
+                x + baseSize + pairingBandSize,
+                y + baseSize * 0.5f,
+                x + baseSize,
+                y + baseSize,
             )
             PairingSide.TOP -> Triangle(
                 x,
-                y + tileSize,
-                x + tileSize * 0.5f,
-                y + tileSize + pairingBandSize,
-                x + tileSize,
-                y + tileSize,
+                y + baseSize,
+                x + baseSize * 0.5f,
+                y + baseSize + pairingBandSize,
+                x + baseSize,
+                y + baseSize,
             )
             PairingSide.BOTTOM -> Triangle(
                 x,
                 y,
-                x + tileSize,
+                x + baseSize,
                 y,
-                x + tileSize * 0.5f,
+                x + baseSize * 0.5f,
                 y - pairingBandSize,
             )
         }
@@ -375,31 +313,31 @@ class NucleotideRenderer(
     private fun roundedOnSide(position: Vector2, side: PairingSide): Arc {
         val x = position.x
         val y = position.y
-        val capRadius = tileSize * 0.5f
+        val capRadius = baseSize * 0.5f
         return when (side) {
             PairingSide.LEFT -> Arc(
                     x,
-                    y + tileSize * 0.5f,
+                    y + baseSize * 0.5f,
                     capRadius,
                     90f,
                     180f,
                 )
             PairingSide.RIGHT -> Arc(
-                    x + tileSize,
-                    y + tileSize * 0.5f,
+                    x + baseSize,
+                    y + baseSize * 0.5f,
                     capRadius,
                     -90f,
                     180f,
                 )
             PairingSide.TOP -> Arc(
-                    x + tileSize * 0.5f,
-                    y + tileSize,
+                    x + baseSize * 0.5f,
+                    y + baseSize,
                     capRadius,
                     0f,
                     180f,
                 )
             PairingSide.BOTTOM -> Arc(
-                    x + tileSize * 0.5f,
+                    x + baseSize * 0.5f,
                     y,
                     capRadius,
                     -180f,
@@ -411,31 +349,31 @@ class NucleotideRenderer(
     private fun roundedSocketOnSide(position: Vector2, side: PairingSide): Arc {
         val x = position.x
         val y = position.y
-        val capRadius = tileSize * 0.5f
+        val capRadius = baseSize * 0.5f
         return when (side) {
             PairingSide.LEFT -> Arc(
                 x - capRadius,
-                y + tileSize * 0.5f,
+                y + baseSize * 0.5f,
                 capRadius,
                 -90f,
                 180f,
             )
             PairingSide.RIGHT -> Arc(
-                x + tileSize + capRadius,
-                y + tileSize * 0.5f,
+                x + baseSize + capRadius,
+                y + baseSize * 0.5f,
                 capRadius,
                 90f,
                 180f,
             )
             PairingSide.TOP -> Arc(
-                x + tileSize * 0.5f,
-                y + tileSize + capRadius,
+                x + baseSize * 0.5f,
+                y + baseSize + capRadius,
                 capRadius,
                 -180f,
                 180f,
             )
             PairingSide.BOTTOM -> Arc(
-                x + tileSize * 0.5f,
+                x + baseSize * 0.5f,
                 y - capRadius,
                 capRadius,
                 0f,

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
@@ -39,7 +39,7 @@ class NucleotideRendererTest {
     }
 
     @Test
-    fun `geometryFor keeps every nucleotide shape inside tile bounds`() {
+    fun `geometryFor keeps every nucleotide shape inside the geometry test window`() {
         val origin = Vector2(10f, 20f)
         val nucleotides = listOf(Nucleotide.A, Nucleotide.U, Nucleotide.C, Nucleotide.G)
         val pairingSides = listOf(PairingSide.LEFT, PairingSide.RIGHT, PairingSide.TOP, PairingSide.BOTTOM)
@@ -47,7 +47,7 @@ class NucleotideRendererTest {
         nucleotides.forEach { nucleotide ->
             pairingSides.forEach { pairingSide ->
                 val geometry = renderer.geometryFor(nucleotide, origin, NucleotideOrientation(pairingSide))
-                assertTrue(renderer.boundsWithinTile(geometry, origin), "Expected $nucleotide on $pairingSide to stay inside tile bounds")
+                assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin), "Expected $nucleotide on $pairingSide to stay inside the geometry test window")
             }
         }
     }
@@ -89,7 +89,7 @@ class NucleotideRendererTest {
     }
 
     @Test
-    fun `boundsWithinTile accepts outline arcs that only sweep inside the tile`() {
+    fun `isWithinNucleotideGeometryTestWindow accepts outline arcs that only sweep inside the tile`() {
         val origin = Vector2(0f, 0f)
         val geometry = NucleotideGeometry(
             filledTriangles = emptyList(),
@@ -97,7 +97,7 @@ class NucleotideRendererTest {
             filledArcs = emptyList(),
             arcs = listOf(
                 Arc(
-                    x = origin.x - renderer.tileSize * 0.75f,
+                    x = origin.x - renderer.baseSize * 0.75f,
                     y = origin.y,
                     radius = 10f,
                     startDegrees = -90f,
@@ -108,11 +108,11 @@ class NucleotideRendererTest {
             lines = emptyList(),
         )
 
-        assertTrue(renderer.boundsWithinTile(geometry, origin))
+        assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin))
     }
 
     @Test
-    fun `boundsWithinTile accepts filled arcs that only sweep inside the tile`() {
+    fun `isWithinNucleotideGeometryTestWindow accepts filled arcs that only sweep inside the tile`() {
         val origin = Vector2(0f, 0f)
         val geometry = NucleotideGeometry(
             filledTriangles = emptyList(),
@@ -120,7 +120,7 @@ class NucleotideRendererTest {
             filledArcs = listOf(
                 Arc(
                     x = origin.x,
-                    y = origin.y - renderer.tileSize * 0.75f,
+                    y = origin.y - renderer.baseSize * 0.75f,
                     radius = 10f,
                     startDegrees = 0f,
                     degrees = 180f,
@@ -131,6 +131,57 @@ class NucleotideRendererTest {
             lines = emptyList(),
         )
 
-        assertTrue(renderer.boundsWithinTile(geometry, origin))
+        assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin))
+    }
+
+
+    private fun isWithinNucleotideGeometryTestWindow(geometry: NucleotideGeometry, position: Vector2): Boolean {
+        val minX = position.x - renderer.baseSize * 0.75f
+        val maxX = position.x + renderer.baseSize * 1.75f
+        val minY = position.y - renderer.baseSize * 0.75f
+        val maxY = position.y + renderer.baseSize * 1.75f
+
+        val rectsInBounds = geometry.filledRects.all { rect ->
+            rect.x >= minX &&
+                rect.y >= minY &&
+                rect.x + rect.width <= maxX &&
+                rect.y + rect.height <= maxY
+        }
+
+        if (!rectsInBounds) return false
+
+        val filledTrianglesInBounds = geometry.filledTriangles.all { triangle ->
+            val xs = listOf(triangle.x1, triangle.x2, triangle.x3)
+            val ys = listOf(triangle.y1, triangle.y2, triangle.y3)
+            xs.all { it in minX..maxX } && ys.all { it in minY..maxY }
+        }
+
+        if (!filledTrianglesInBounds) return false
+
+        val trianglesInBounds = geometry.triangles.all { triangle ->
+            val xs = listOf(triangle.x1, triangle.x2, triangle.x3)
+            val ys = listOf(triangle.y1, triangle.y2, triangle.y3)
+            xs.all { it in minX..maxX } && ys.all { it in minY..maxY }
+        }
+
+        if (!trianglesInBounds) return false
+
+        val filledArcsInBounds = geometry.filledArcs.all { arc ->
+            renderer.arcBounds(arc, includeCenter = true).isWithin(minX, maxX, minY, maxY)
+        }
+
+        if (!filledArcsInBounds) return false
+
+        val arcsInBounds = geometry.arcs.all { arc ->
+            renderer.arcBounds(arc).isWithin(minX, maxX, minY, maxY)
+        }
+
+        if (!arcsInBounds) return false
+
+        return geometry.lines.all { line ->
+            listOf(line.a, line.b).all { point ->
+                point.x in minX..maxX && point.y in minY..maxY
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Make the nucleotide renderer use a clearer `baseSize` parameter for geometry calculations and central text positioning instead of the ambiguous `tileSize`.
- Simplify the renderer surface API by removing an internal bounds helper and move the bounds verification logic into the test suite so tests can control the test window.

### Description

- Renamed the renderer property from `tileSize` to `baseSize` and updated all geometry calculations to use `baseSize` (including `pairingBandSize`, rectangle sizes, triangle points, arc centers and radii, and text centering).
- Removed the internal `boundsWithinTile` method from `NucleotideRenderer` and updated callers in tests to use a new test-local helper `isWithinNucleotideGeometryTestWindow` implementing equivalent bounds checks relative to `baseSize`.
- Updated `NucleotideRendererTest` to reference `baseSize` where offsets are required and renamed test methods and assertions that referenced the old bounds helper to use the new test helper name.

### Testing

- Updated unit tests in `simulator/src/test/kotlin/.../NucleotideRendererTest.kt` and ran the simulator unit tests targeting the renderer; the modified `NucleotideRendererTest` passed.
- Verified arc bounding tests (`arcBounds`) still validate swept extrema behavior and continued to pass after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f193750f9c8329849af2dacad695d3)