### PR TITLE
Add polygon geometry pipeline and immediate-mode polygon rendering to simulator

### DIFF
--- a/simulator/README.md
+++ b/simulator/README.md
@@ -52,6 +52,7 @@ On launch, the simulator renders all of the following together in a single stati
 Rendering now uses type-specific renderers and includes both text labels and a minimal graphical treatment:
 
 - `NucleotideRenderer` for orientation-aware schematic nucleotide silhouettes with centered symbols
+- `geometry` package for reusable simulator-side primitives (`Geometry`, `Arc`, `Polygon`, etc.)
 - `NucleotideSequenceRenderer` for sequence layout, backbones, and direction indicators
 - `DnaRenderer` for duplex layout and pair connectors built on the sequence renderer
 
@@ -117,3 +118,12 @@ Planned follow-up work includes:
 - scene/world object management
 - dynamic simulation/render integration
 - richer molecule/organism rendering and debug overlays
+
+
+### Geometry and polygon rendering
+
+Simulator rendering geometry is centralized in `rendering/geometry` so shapes, bounds rules, and construction helpers evolve together.
+`Geometry.render(...)` now supports polygon lists in addition to rects/triangles/arcs/lines, and `RenderContext` can draw filled or wireframe polygons from raw vertex data.
+
+For complex connectors, use `polygon.of(...).add(...).close()` and `arc(start, center, end, segments)` to approximate curved edges as vertices.
+This keeps awkward silhouettes composable and prepares the pipeline for later startup-time sprite generation.

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -125,5 +125,7 @@ Planned follow-up work includes:
 Simulator rendering geometry is centralized in `rendering/geometry` so shapes, bounds rules, and construction helpers evolve together.
 `Geometry.render(...)` now supports polygon lists in addition to rects/triangles/arcs/lines, and `RenderContext` can draw filled or wireframe polygons from raw vertex data.
 
-For complex connectors, use `polygon.of(...).add(...).close()` and `arc(start, center, end, segments)` to approximate curved edges as vertices.
+For complex connectors, use `Polygon.of(...).add(...).close()` and `arc(start, center, end, segments, sweepDirection)` to approximate curved edges as vertices.
+Filled polygons are triangulated from that outline data before rendering, so curved and concave silhouettes do not need to be authored as triangle fans by hand.
+Set `sweepDirection` explicitly when `start` and `end` sit opposite each other on a diameter, because those points alone do not determine which side of the circle should be traced.
 This keeps awkward silhouettes composable and prepares the pipeline for later startup-time sprite generation.

--- a/simulator/src/main/kotlin/life/sim/simulator/SimulatorApplication.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/SimulatorApplication.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator
+import com.badlogic.gdx.graphics.glutils.ImmediateModeRenderer20
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.utils.ScreenUtils
 import life.sim.simulator.rendering.DnaRenderer
@@ -22,6 +23,7 @@ class SimulatorApplication : ApplicationAdapter() {
     private lateinit var batch: SpriteBatch
     private lateinit var font: BitmapFont
     private lateinit var shapeRenderer: ShapeRenderer
+    private lateinit var immediateModeRenderer: ImmediateModeRenderer20
     private lateinit var renderContext: RenderContext
     private val camera = OrthographicCamera()
     private lateinit var currentScene: Scene
@@ -41,6 +43,7 @@ class SimulatorApplication : ApplicationAdapter() {
             setUseIntegerPositions(true)
         }
         shapeRenderer = ShapeRenderer()
+        immediateModeRenderer = ImmediateModeRenderer20(false, true, 0)
         updateProjectionMatrices(Gdx.graphics.width, Gdx.graphics.height)
         initializeRenderers()
         renderContext = RenderContext(
@@ -49,6 +52,7 @@ class SimulatorApplication : ApplicationAdapter() {
             shapeRenderer = shapeRenderer,
             viewportWidth = Gdx.graphics.width.toFloat(),
             viewportHeight = Gdx.graphics.height.toFloat(),
+            immediateModeRenderer = immediateModeRenderer,
         )
         currentScene = DemoScene.sample()
         currentScene.init()
@@ -76,6 +80,7 @@ class SimulatorApplication : ApplicationAdapter() {
         batch.dispose()
         font.dispose()
         shapeRenderer.dispose()
+        immediateModeRenderer.dispose()
     }
 
     private fun updateProjectionMatrices(width: Int, height: Int) {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -53,6 +53,7 @@ class NucleotideRenderer(
         val arcs = mutableListOf<Arc>()
         val triangles = mutableListOf<Triangle>()
         val lines = mutableListOf<Line>()
+        val polygons = mutableListOf<Polygon>()
 
         when (profile.family) {
             ConnectorFamily.ANGLED -> {
@@ -71,7 +72,7 @@ class NucleotideRenderer(
                     filledArcs += roundedOnSide(position, orientation.pairingSide)
                 } else {
                     filledRects += Rect(position.x, position.y, baseSize, baseSize)
-                    arcs += roundedSocketOnSide(position, orientation.pairingSide)
+                    polygons += roundedSocketPolygonOnSide(position, orientation.pairingSide)
                 }
             }
         }
@@ -83,6 +84,7 @@ class NucleotideRenderer(
             arcs = arcs,
             triangles = triangles,
             lines = lines,
+            polygons = polygons,
         )
     }
 
@@ -244,43 +246,23 @@ class NucleotideRenderer(
         }
     }
 
-    private fun roundedSocketOnSide(position: Vector2, side: PairingSide): Arc {
+    private fun roundedSocketPolygonOnSide(position: Vector2, side: PairingSide): Polygon {
         val x = position.x
         val y = position.y
-        val capRadius = baseSize * 0.7f
+        val capRadius = baseSize * 0.35f
         return when (side) {
-            PairingSide.LEFT -> Arc(
-                x - capRadius,
-                y + baseSize * 0.5f,
-                capRadius,
-                -42f,
-                84f,
-                baseSize * 0.08f,
-            )
-            PairingSide.RIGHT -> Arc(
-                x + baseSize + capRadius,
-                y + baseSize * 0.5f,
-                capRadius,
-                138f,
-                84f,
-                baseSize * 0.08f,
-            )
-            PairingSide.TOP -> Arc(
-                x + baseSize * 0.5f,
-                y + baseSize + capRadius,
-                capRadius,
-                -132f,
-                84f,
-                baseSize * 0.08f,
-            )
-            PairingSide.BOTTOM -> Arc(
-                x + baseSize * 0.5f,
-                y - capRadius,
-                capRadius,
-                48f,
-                84f,
-                baseSize * 0.08f,
-            )
+            PairingSide.LEFT -> polygon.of(Vector2(x, y + baseSize), Vector2(x, y))
+                .add(arc(Vector2(x, y), Vector2(x - capRadius, y + baseSize * 0.5f), Vector2(x, y + baseSize), segments = 10))
+                .close()
+            PairingSide.RIGHT -> polygon.of(Vector2(x + baseSize, y), Vector2(x + baseSize, y + baseSize))
+                .add(arc(Vector2(x + baseSize, y + baseSize), Vector2(x + baseSize + capRadius, y + baseSize * 0.5f), Vector2(x + baseSize, y), segments = 10))
+                .close()
+            PairingSide.TOP -> polygon.of(Vector2(x, y + baseSize), Vector2(x + baseSize, y + baseSize))
+                .add(arc(Vector2(x + baseSize, y + baseSize), Vector2(x + baseSize * 0.5f, y + baseSize), Vector2(x, y + baseSize), segments = 10))
+                .close()
+            PairingSide.BOTTOM -> polygon.of(Vector2(x + baseSize, y), Vector2(x, y))
+                .add(arc(Vector2(x, y), Vector2(x + baseSize * 0.5f, y), Vector2(x + baseSize, y), segments = 10))
+                .close()
         }
     }
 

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -71,7 +71,6 @@ class NucleotideRenderer(
                     filledRects += Rect(position.x, position.y, baseSize, baseSize)
                     filledArcs += roundedOnSide(position, orientation.pairingSide)
                 } else {
-                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
                     polygons += roundedSocketPolygonOnSide(position, orientation.pairingSide)
                 }
             }
@@ -110,6 +109,7 @@ class NucleotideRenderer(
                     y + baseSize,
                 ),
             )
+
             PairingSide.BOTTOM -> listOf(
                 Triangle(
                     x,
@@ -128,6 +128,7 @@ class NucleotideRenderer(
                     y - pairingBandSize,
                 ),
             )
+
             PairingSide.LEFT -> listOf(
                 Triangle(
                     x,
@@ -146,6 +147,7 @@ class NucleotideRenderer(
                     y,
                 ),
             )
+
             PairingSide.RIGHT -> listOf(
                 Triangle(
                     x + baseSize,
@@ -179,6 +181,7 @@ class NucleotideRenderer(
                 x - pairingBandSize,
                 y + baseSize * 0.5f,
             )
+
             PairingSide.RIGHT -> Triangle(
                 x + baseSize,
                 y,
@@ -187,6 +190,7 @@ class NucleotideRenderer(
                 x + baseSize,
                 y + baseSize,
             )
+
             PairingSide.TOP -> Triangle(
                 x,
                 y + baseSize,
@@ -195,6 +199,7 @@ class NucleotideRenderer(
                 x + baseSize,
                 y + baseSize,
             )
+
             PairingSide.BOTTOM -> Triangle(
                 x,
                 y,
@@ -219,6 +224,7 @@ class NucleotideRenderer(
                 180f,
                 baseSize * 0.08f,
             )
+
             PairingSide.RIGHT -> Arc(
                 x + baseSize,
                 y + baseSize * 0.5f,
@@ -227,6 +233,7 @@ class NucleotideRenderer(
                 180f,
                 baseSize * 0.08f,
             )
+
             PairingSide.TOP -> Arc(
                 x + baseSize * 0.5f,
                 y + baseSize,
@@ -235,6 +242,7 @@ class NucleotideRenderer(
                 180f,
                 baseSize * 0.08f,
             )
+
             PairingSide.BOTTOM -> Arc(
                 x + baseSize * 0.5f,
                 y,
@@ -249,19 +257,81 @@ class NucleotideRenderer(
     private fun roundedSocketPolygonOnSide(position: Vector2, side: PairingSide): Polygon {
         val x = position.x
         val y = position.y
-        val capRadius = baseSize * 0.35f
         return when (side) {
-            PairingSide.LEFT -> polygon.of(Vector2(x, y + baseSize), Vector2(x, y))
-                .add(arc(Vector2(x, y), Vector2(x - capRadius, y + baseSize * 0.5f), Vector2(x, y + baseSize), segments = 10))
+            PairingSide.LEFT -> Polygon.of(
+                Vector2(x + baseSize, y + baseSize),
+                Vector2(x, y + baseSize),
+                Vector2(x - pairingBandSize, y + baseSize),
+            )
+                .add(
+                    arc(
+                        Vector2(x - pairingBandSize, y + baseSize),
+                        Vector2(x - pairingBandSize, y + baseSize * 0.5f),
+                        Vector2(x - pairingBandSize, y),
+                        segments = 10,
+                        sweepDirection = ArcSweepDirection.CLOCKWISE,
+                    ),
+                )
+                .add(
+                    Vector2(x, y),
+                    Vector2(x + baseSize, y),
+                )
                 .close()
-            PairingSide.RIGHT -> polygon.of(Vector2(x + baseSize, y), Vector2(x + baseSize, y + baseSize))
-                .add(arc(Vector2(x + baseSize, y + baseSize), Vector2(x + baseSize + capRadius, y + baseSize * 0.5f), Vector2(x + baseSize, y), segments = 10))
+
+            PairingSide.RIGHT -> Polygon.of(
+                Vector2(x, y + baseSize),
+                Vector2(x + baseSize, y + baseSize),
+                Vector2(x + baseSize + pairingBandSize, y + baseSize),
+            )
+                .add(
+                    arc(
+                        Vector2(x + baseSize + pairingBandSize, y + baseSize),
+                        Vector2(x + baseSize + pairingBandSize, y + baseSize * 0.5f),
+                        Vector2(x + baseSize + pairingBandSize, y),
+                        segments = 10,
+                        sweepDirection = ArcSweepDirection.COUNTERCLOCKWISE,
+                    ),
+                )
+                .add(
+                    Vector2(x + baseSize, y),
+                    Vector2(x, y),
+                )
                 .close()
-            PairingSide.TOP -> polygon.of(Vector2(x, y + baseSize), Vector2(x + baseSize, y + baseSize))
-                .add(arc(Vector2(x + baseSize, y + baseSize), Vector2(x + baseSize * 0.5f, y + baseSize), Vector2(x, y + baseSize), segments = 10))
+
+            PairingSide.TOP -> Polygon.of(
+                Vector2(x, y),
+                Vector2(x + baseSize, y),
+                Vector2(x + baseSize, y + baseSize),
+                Vector2(x + baseSize, y + baseSize + pairingBandSize),
+            )
+                .add(
+                    arc(
+                        Vector2(x + baseSize, y + baseSize + pairingBandSize),
+                        Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize),
+                        Vector2(x, y + baseSize + pairingBandSize),
+                        segments = 10,
+                        sweepDirection = ArcSweepDirection.CLOCKWISE,
+                    ),
+                )
+                .add(Vector2(x, y + baseSize))
                 .close()
-            PairingSide.BOTTOM -> polygon.of(Vector2(x + baseSize, y), Vector2(x, y))
-                .add(arc(Vector2(x, y), Vector2(x + baseSize * 0.5f, y), Vector2(x + baseSize, y), segments = 10))
+
+            PairingSide.BOTTOM -> Polygon.of(
+                Vector2(x + baseSize, y + baseSize),
+                Vector2(x, y + baseSize),
+                Vector2(x, y),
+                Vector2(x, y - pairingBandSize),
+            )
+                .add(
+                    arc(
+                        Vector2(x, y - pairingBandSize),
+                        Vector2(x + baseSize * 0.5f, y - pairingBandSize),
+                        Vector2(x + baseSize, y - pairingBandSize),
+                        segments = 10,
+                        sweepDirection = ArcSweepDirection.CLOCKWISE,
+                    ),
+                )
+                .add(Vector2(x + baseSize, y))
                 .close()
         }
     }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
@@ -1,13 +1,16 @@
 package life.sim.simulator.rendering
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.graphics.g2d.GlyphLayout
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
+import com.badlogic.gdx.graphics.glutils.ImmediateModeRenderer20
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType
 import com.badlogic.gdx.math.MathUtils
 import com.badlogic.gdx.math.Vector2
+import life.sim.simulator.rendering.geometry.PolygonDrawMode
 import kotlin.math.cbrt
 import kotlin.math.max
 
@@ -22,6 +25,7 @@ data class RenderContext(
     val shapeRenderer: ShapeRenderer,
     var viewportWidth: Float,
     var viewportHeight: Float,
+    val immediateModeRenderer: ImmediateModeRenderer20 = ImmediateModeRenderer20(false, true, 0),
 ) {
     private enum class DrawMode {
         NONE,
@@ -120,6 +124,19 @@ data class RenderContext(
 
             shapeRenderer.rectLine(a, b, lineWidth)
         }
+    }
+
+
+    internal fun drawPolygon(vertices: List<Vector2>, drawMode: PolygonDrawMode, color: Color) {
+        if (vertices.size < 3) return
+        finish()
+        val glMode = if (drawMode == PolygonDrawMode.FILLED) GL20.GL_TRIANGLE_FAN else GL20.GL_LINE_STRIP
+        immediateModeRenderer.begin(shapeRenderer.projectionMatrix, glMode)
+        vertices.forEach { vertex ->
+            immediateModeRenderer.color(color.r, color.g, color.b, color.a)
+            immediateModeRenderer.vertex(vertex.x, vertex.y, 0f)
+        }
+        immediateModeRenderer.end()
     }
 
     fun drawText(text: String, x: Float, y: Float, color: Color = Color.WHITE) {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
@@ -25,7 +25,7 @@ data class RenderContext(
     val shapeRenderer: ShapeRenderer,
     var viewportWidth: Float,
     var viewportHeight: Float,
-    val immediateModeRenderer: ImmediateModeRenderer20 = ImmediateModeRenderer20(false, true, 0),
+    val immediateModeRenderer: ImmediateModeRenderer20,
 ) {
     private enum class DrawMode {
         NONE,

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
@@ -10,7 +10,7 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType
 import com.badlogic.gdx.math.MathUtils
 import com.badlogic.gdx.math.Vector2
-import life.sim.simulator.rendering.geometry.PolygonDrawMode
+import life.sim.simulator.rendering.geometry.*
 import kotlin.math.cbrt
 import kotlin.math.max
 
@@ -130,9 +130,22 @@ data class RenderContext(
     internal fun drawPolygon(vertices: List<Vector2>, drawMode: PolygonDrawMode, color: Color) {
         if (vertices.size < 3) return
         finish()
-        val glMode = if (drawMode == PolygonDrawMode.FILLED) GL20.GL_TRIANGLE_FAN else GL20.GL_LINE_STRIP
+        val renderVertices = if (drawMode == PolygonDrawMode.FILLED) {
+            triangulatePolygon(vertices).flatMap { triangle ->
+                listOf(
+                    Vector2(triangle.x1, triangle.y1),
+                    Vector2(triangle.x2, triangle.y2),
+                    Vector2(triangle.x3, triangle.y3),
+                )
+            }
+        } else {
+            vertices
+        }
+        if (renderVertices.isEmpty()) return
+
+        val glMode = if (drawMode == PolygonDrawMode.FILLED) GL20.GL_TRIANGLES else GL20.GL_LINE_STRIP
         immediateModeRenderer.begin(shapeRenderer.projectionMatrix, glMode)
-        vertices.forEach { vertex ->
+        renderVertices.forEach { vertex ->
             immediateModeRenderer.color(color.r, color.g, color.b, color.a)
             immediateModeRenderer.vertex(vertex.x, vertex.y, 0f)
         }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Geometry.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Geometry.kt
@@ -10,6 +10,7 @@ internal data class Geometry(
     val arcs: List<Arc>,
     val triangles: List<Triangle>,
     val lines: List<Line>,
+    val polygons: List<Polygon>,
 )
 
 internal fun Geometry.render(context: RenderContext, color: Color) {
@@ -30,6 +31,9 @@ internal fun Geometry.render(context: RenderContext, color: Color) {
     }
     this.lines.forEach { line ->
         context.drawLine(line.a, line.b, line.width, color)
+    }
+    this.polygons.forEach { polygon ->
+        context.drawPolygon(polygon.vertices, polygon.drawMode, color)
     }
 }
 

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
@@ -1,0 +1,72 @@
+package life.sim.simulator.rendering.geometry
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.Vector2
+
+internal enum class PolygonDrawMode {
+    FILLED,
+    WIREFRAME,
+}
+
+internal data class Polygon(
+    val vertices: List<Vector2>,
+    val drawMode: PolygonDrawMode,
+)
+
+internal object polygon {
+    fun of(vararg vertices: Vector2, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): PolygonBuilder =
+        PolygonBuilder(vertices = vertices.toList().map(Vector2::cpy).toMutableList(), drawMode = drawMode)
+}
+
+internal data class ArcPath(
+    val start: Vector2,
+    val center: Vector2,
+    val end: Vector2,
+    val segments: Int = 18,
+)
+
+internal class PolygonBuilder internal constructor(
+    private val vertices: MutableList<Vector2>,
+    private val drawMode: PolygonDrawMode,
+) {
+    fun add(vararg points: Vector2): PolygonBuilder {
+        vertices += points.map(Vector2::cpy)
+        return this
+    }
+
+    fun add(points: Iterable<Vector2>): PolygonBuilder {
+        vertices += points.map(Vector2::cpy)
+        return this
+    }
+
+    fun close(): Polygon {
+        val closedVertices = vertices.toMutableList()
+        if (closedVertices.size > 2 && closedVertices.first() != closedVertices.last()) {
+            closedVertices += closedVertices.first().cpy()
+        }
+        return Polygon(vertices = closedVertices, drawMode = drawMode)
+    }
+}
+
+internal fun arc(start: Vector2, center: Vector2, end: Vector2, segments: Int = 18): List<Vector2> {
+    require(segments >= 2) { "segments must be >= 2." }
+    val radius = start.dst(center)
+    require(radius > 0f) { "Arc radius must be > 0." }
+
+    val startAngle = kotlin.math.atan2((start.y - center.y).toDouble(), (start.x - center.x).toDouble())
+    val endAngle = kotlin.math.atan2((end.y - center.y).toDouble(), (end.x - center.x).toDouble())
+
+    var delta = endAngle - startAngle
+    if (delta <= 0.0) {
+        delta += Math.PI * 2.0
+    }
+
+    return (0..segments).map { i ->
+        val t = i.toDouble() / segments
+        val angle = startAngle + delta * t
+        Vector2(
+            (center.x + radius * kotlin.math.cos(angle)).toFloat(),
+            (center.y + radius * kotlin.math.sin(angle)).toFloat(),
+        )
+    }
+}

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
@@ -1,6 +1,6 @@
 package life.sim.simulator.rendering.geometry
 
-import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.EarClippingTriangulator
 import com.badlogic.gdx.math.Vector2
 
 internal enum class PolygonDrawMode {
@@ -8,22 +8,20 @@ internal enum class PolygonDrawMode {
     WIREFRAME,
 }
 
+internal enum class ArcSweepDirection {
+    COUNTERCLOCKWISE,
+    CLOCKWISE,
+}
+
 internal data class Polygon(
     val vertices: List<Vector2>,
     val drawMode: PolygonDrawMode,
-)
-
-internal object polygon {
-    fun of(vararg vertices: Vector2, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): PolygonBuilder =
-        PolygonBuilder(vertices = vertices.toList().map(Vector2::cpy).toMutableList(), drawMode = drawMode)
+) {
+    companion object {
+        fun of(vararg vertices: Vector2, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): PolygonBuilder =
+            PolygonBuilder(vertices = vertices.toList().map(Vector2::cpy).toMutableList(), drawMode = drawMode)
+    }
 }
-
-internal data class ArcPath(
-    val start: Vector2,
-    val center: Vector2,
-    val end: Vector2,
-    val segments: Int = 18,
-)
 
 internal class PolygonBuilder internal constructor(
     private val vertices: MutableList<Vector2>,
@@ -48,7 +46,23 @@ internal class PolygonBuilder internal constructor(
     }
 }
 
-internal fun arc(start: Vector2, center: Vector2, end: Vector2, segments: Int = 18): List<Vector2> {
+/**
+ * Generates an arc from `start` to `end` around `center`.
+ *
+ * The radius is taken from the distance between `start` and `center`, and the returned list contains
+ * `segments + 1` evenly spaced points including the generated start and final arc point.
+ *
+ * `sweepDirection` controls which side of the circle is traced when `start` and `end` alone are ambiguous,
+ * such as opposite points on the same diameter. The final point coincides with `end` only when `end` lies on
+ * that same circle.
+ */
+internal fun arc(
+    start: Vector2,
+    center: Vector2,
+    end: Vector2,
+    segments: Int = 18,
+    sweepDirection: ArcSweepDirection = ArcSweepDirection.COUNTERCLOCKWISE,
+): List<Vector2> {
     require(segments >= 2) { "segments must be >= 2." }
     val radius = start.dst(center)
     require(radius > 0f) { "Arc radius must be > 0." }
@@ -57,8 +71,14 @@ internal fun arc(start: Vector2, center: Vector2, end: Vector2, segments: Int = 
     val endAngle = kotlin.math.atan2((end.y - center.y).toDouble(), (end.x - center.x).toDouble())
 
     var delta = endAngle - startAngle
-    if (delta <= 0.0) {
-        delta += Math.PI * 2.0
+    if (sweepDirection == ArcSweepDirection.COUNTERCLOCKWISE) {
+        if (delta <= 0.0) {
+            delta += Math.PI * 2.0
+        }
+    } else {
+        if (delta >= 0.0) {
+            delta -= Math.PI * 2.0
+        }
     }
 
     return (0..segments).map { i ->
@@ -70,3 +90,36 @@ internal fun arc(start: Vector2, center: Vector2, end: Vector2, segments: Int = 
         )
     }
 }
+
+internal fun triangulatePolygon(vertices: List<Vector2>): List<Triangle> {
+    val outline = polygonOutline(vertices)
+    if (outline.size < 3) return emptyList()
+
+    val packedVertices = FloatArray(outline.size * 2)
+    outline.forEachIndexed { index, vertex ->
+        packedVertices[index * 2] = vertex.x
+        packedVertices[index * 2 + 1] = vertex.y
+    }
+
+    val triangleIndices = EarClippingTriangulator().computeTriangles(packedVertices)
+    val indices = triangleIndices.items
+
+    return buildList(triangleIndices.size / 3) {
+        var index = 0
+        while (index < triangleIndices.size) {
+            val a = outline[indices[index].toInt()]
+            val b = outline[indices[index + 1].toInt()]
+            val c = outline[indices[index + 2].toInt()]
+            add(Triangle(a.x, a.y, b.x, b.y, c.x, c.y))
+            index += 3
+        }
+    }
+}
+
+internal fun polygonOutline(vertices: List<Vector2>): List<Vector2> =
+    if (vertices.size > 1 && vertices.first() == vertices.last()) {
+        vertices.dropLast(1)
+    } else {
+        vertices
+    }
+

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
@@ -73,6 +73,7 @@ class NucleotideRendererTest {
             ),
             triangles = emptyList(),
             lines = emptyList(),
+            polygons = emptyList(),
         )
 
         assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin))
@@ -97,6 +98,7 @@ class NucleotideRendererTest {
             arcs = emptyList(),
             triangles = emptyList(),
             lines = emptyList(),
+            polygons = emptyList(),
         )
 
         assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin))
@@ -146,10 +148,15 @@ class NucleotideRendererTest {
 
         if (!arcsInBounds) return false
 
-        return geometry.lines.all { line ->
+        val linesInBounds = geometry.lines.all { line ->
             listOf(line.a, line.b).all { point ->
                 point.x in minX..maxX && point.y in minY..maxY
             }
+        }
+        if (!linesInBounds) return false
+
+        return geometry.polygons.all { polygon ->
+            polygon.vertices.all { point -> point.x in minX..maxX && point.y in minY..maxY }
         }
     }
 }

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
@@ -104,6 +104,61 @@ class NucleotideRendererTest {
         assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin))
     }
 
+    @Test
+    fun `geometryFor renders rounded indentations as a single polygon with an outward concave socket`() {
+        val origin = Vector2(10f, 20f)
+        val baseCorners = listOf(
+            Vector2(origin.x, origin.y),
+            Vector2(origin.x + renderer.baseSize, origin.y),
+            Vector2(origin.x, origin.y + renderer.baseSize),
+            Vector2(origin.x + renderer.baseSize, origin.y + renderer.baseSize),
+        )
+
+        listOf(PairingSide.LEFT, PairingSide.RIGHT, PairingSide.TOP, PairingSide.BOTTOM).forEach { pairingSide ->
+            val geometry = renderer.geometryFor(Nucleotide.G, origin, NucleotideOrientation(pairingSide))
+            val polygon = geometry.polygons.single()
+
+            assertEquals(emptyList(), geometry.filledRects)
+            assertTrue(baseCorners.all(polygon.vertices::contains), "Expected the rounded indentation polygon to keep the rectangular body corners")
+            assertTrue(polygon.vertices.first() == polygon.vertices.last(), "Expected the rounded indentation polygon to be closed")
+            assertTrue(polygonArea(polygon.vertices) > renderer.baseSize * renderer.baseSize, "Expected the rounded indentation polygon to cover more area than the base square")
+
+            when (pairingSide) {
+                PairingSide.LEFT -> {
+                    assertTrue(polygon.vertices.any { it.x < origin.x }, "Expected the left rounded socket to extend beyond the left edge")
+                    assertTrue(
+                        polygon.vertices.any { approximatelyEqual(it.x, origin.x) && approximatelyEqual(it.y, origin.y + renderer.baseSize * 0.5f) },
+                        "Expected the left rounded socket to curve back inward to the left body edge",
+                    )
+                }
+
+                PairingSide.RIGHT -> {
+                    assertTrue(polygon.vertices.any { it.x > origin.x + renderer.baseSize }, "Expected the right rounded socket to extend beyond the right edge")
+                    assertTrue(
+                        polygon.vertices.any { approximatelyEqual(it.x, origin.x + renderer.baseSize) && approximatelyEqual(it.y, origin.y + renderer.baseSize * 0.5f) },
+                        "Expected the right rounded socket to curve back inward to the right body edge",
+                    )
+                }
+
+                PairingSide.TOP -> {
+                    assertTrue(polygon.vertices.any { it.y > origin.y + renderer.baseSize }, "Expected the top rounded socket to extend beyond the top edge")
+                    assertTrue(
+                        polygon.vertices.any { approximatelyEqual(it.x, origin.x + renderer.baseSize * 0.5f) && approximatelyEqual(it.y, origin.y + renderer.baseSize) },
+                        "Expected the top rounded socket to curve back inward to the top body edge",
+                    )
+                }
+
+                PairingSide.BOTTOM -> {
+                    assertTrue(polygon.vertices.any { it.y < origin.y }, "Expected the bottom rounded socket to extend beyond the bottom edge")
+                    assertTrue(
+                        polygon.vertices.any { approximatelyEqual(it.x, origin.x + renderer.baseSize * 0.5f) && approximatelyEqual(it.y, origin.y) },
+                        "Expected the bottom rounded socket to curve back inward to the bottom body edge",
+                    )
+                }
+            }
+        }
+    }
+
 
     private fun isWithinNucleotideGeometryTestWindow(geometry: Geometry, position: Vector2): Boolean {
         val minX = position.x - renderer.baseSize * 0.75f
@@ -159,4 +214,18 @@ class NucleotideRendererTest {
             polygon.vertices.all { point -> point.x in minX..maxX && point.y in minY..maxY }
         }
     }
+
+    private fun polygonArea(vertices: List<Vector2>): Float {
+        val outline = polygonOutline(vertices)
+        var doubledArea = 0f
+        for (index in outline.indices) {
+            val current = outline[index]
+            val next = outline[(index + 1) % outline.size]
+            doubledArea += current.x * next.y - next.x * current.y
+        }
+        return kotlin.math.abs(doubledArea) * 0.5f
+    }
+
+    private fun approximatelyEqual(a: Float, b: Float, tolerance: Float = 0.0001f): Boolean =
+        kotlin.math.abs(a - b) <= tolerance
 }

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonArcTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonArcTest.kt
@@ -1,0 +1,36 @@
+package life.sim.simulator.rendering.geometry
+
+import com.badlogic.gdx.math.Vector2
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PolygonArcTest {
+    @Test
+    fun `arc defaults to the counterclockwise sweep for opposite points on a diameter`() {
+        val points = arc(
+            start = Vector2(0f, 0f),
+            center = Vector2(0f, 10f),
+            end = Vector2(0f, 20f),
+            segments = 4,
+        )
+
+        assertEquals(5, points.size)
+        assertTrue(points[2].x > 0f, "Expected the default counterclockwise sweep to pass on the positive-x side of the circle")
+    }
+
+    @Test
+    fun `arc can sweep clockwise for opposite points on a diameter`() {
+        val points = arc(
+            start = Vector2(0f, 0f),
+            center = Vector2(0f, 10f),
+            end = Vector2(0f, 20f),
+            segments = 4,
+            sweepDirection = ArcSweepDirection.CLOCKWISE,
+        )
+
+        assertEquals(5, points.size)
+        assertTrue(points[2].x < 0f, "Expected the clockwise sweep to pass on the negative-x side of the circle")
+    }
+}
+

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonTriangulationTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonTriangulationTest.kt
@@ -1,0 +1,61 @@
+package life.sim.simulator.rendering.geometry
+
+import com.badlogic.gdx.math.Vector2
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PolygonTriangulationTest {
+    @Test
+    fun `polygonOutline drops a duplicated closing vertex`() {
+        val outline = polygonOutline(
+            listOf(
+                Vector2(0f, 0f),
+                Vector2(2f, 0f),
+                Vector2(1f, 1f),
+                Vector2(0f, 0f),
+            ),
+        )
+
+        assertEquals(3, outline.size)
+        assertEquals(Vector2(0f, 0f), outline.first())
+        assertEquals(Vector2(1f, 1f), outline.last())
+    }
+
+    @Test
+    fun `triangulatePolygon preserves area for a concave closed outline`() {
+        val vertices = listOf(
+            Vector2(0f, 0f),
+            Vector2(4f, 0f),
+            Vector2(4f, 4f),
+            Vector2(2f, 2f),
+            Vector2(0f, 4f),
+            Vector2(0f, 0f),
+        )
+
+        val triangles = triangulatePolygon(vertices)
+
+        assertEquals(3, triangles.size)
+        assertEquals(polygonArea(vertices), triangles.sumOf(::triangleArea).toFloat(), 0.0001f)
+    }
+
+    private fun polygonArea(vertices: List<Vector2>): Float {
+        val outline = polygonOutline(vertices)
+        var doubledArea = 0f
+        for (index in outline.indices) {
+            val current = outline[index]
+            val next = outline[(index + 1) % outline.size]
+            doubledArea += current.x * next.y - next.x * current.y
+        }
+        return abs(doubledArea) * 0.5f
+    }
+
+    private fun triangleArea(triangle: Triangle): Double =
+        abs(
+            triangle.x1 * (triangle.y2 - triangle.y3) +
+                triangle.x2 * (triangle.y3 - triangle.y1) +
+                triangle.x3 * (triangle.y1 - triangle.y2),
+        ).toDouble() * 0.5
+}
+
+


### PR DESCRIPTION
### Motivation
- Continue the simulator geometry refactor so complex nucleotide silhouettes can be expressed as reusable polygons instead of ad-hoc primitives. 
- Provide a clean foundation for later startup-time sprite generation by centralizing polygon/curve helpers and bounds logic in the `geometry` package.

### Description
- Add `Polygon`, `PolygonBuilder`, `PolygonDrawMode`, a fluent `polygon.of(...).add(...).close()` API, and an `arc(start, center, end, segments)` vertex-approximation helper in `rendering/geometry`.
- Extend `Geometry` to carry polygon lists and render them via the render pipeline.
- Expose lower-level polygon drawing in `RenderContext` using `ImmediateModeRenderer20` with filled (`GL_TRIANGLE_FAN`) and wireframe (`GL_LINE_STRIP`) modes via an internal `drawPolygon(...)` method.
- Replace the rounded indentation connector case in `NucleotideRenderer` with a polygon-based construction using the new arc approximation, update tests to validate polygon vertices, and document the new geometry direction in `simulator/README.md`.

### Testing
- Ran the simulator unit tests for the changed areas with `./gradlew :simulator:test --tests "life.sim.simulator.rendering.NucleotideRendererTest" --tests "life.sim.simulator.rendering.geometry.ArcBoundsTest"` and the test suite completed successfully.
- Updated tests exercise polygon inclusion in the nucleotide geometry window and the existing arc bounds checks, both passing under the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26c5b8ca08329a7604276817afa5c)