### PR TITLE
Add Polygon.rect/triangle/circle helpers and tests

### DIFF
--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
@@ -35,6 +35,7 @@ internal data class Polygon(
 
         fun circle(center: Vector2, radius: Float, segments: Int = 24, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon {
             require(segments >= 3) { "segments must be >= 3." }
+            require(radius > 0f) { "radius must be > 0." }
             val points = (0 until segments).map { i ->
                 val angle = (Math.PI * 2.0 * i.toDouble()) / segments.toDouble()
                 Vector2(

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
@@ -20,6 +20,31 @@ internal data class Polygon(
     companion object {
         fun of(vararg vertices: Vector2, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): PolygonBuilder =
             PolygonBuilder(vertices = vertices.toList().map(Vector2::cpy).toMutableList(), drawMode = drawMode)
+
+        fun rect(x: Float, y: Float, width: Float, height: Float, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon =
+            of(
+                Vector2(x, y),
+                Vector2(x + width, y),
+                Vector2(x + width, y + height),
+                Vector2(x, y + height),
+                drawMode = drawMode,
+            ).close()
+
+        fun triangle(a: Vector2, b: Vector2, c: Vector2, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon =
+            of(a, b, c, drawMode = drawMode).close()
+
+        fun circle(center: Vector2, radius: Float, segments: Int = 24, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon {
+            require(segments >= 3) { "segments must be >= 3." }
+            val points = (0 until segments).map { i ->
+                val angle = (Math.PI * 2.0 * i.toDouble()) / segments.toDouble()
+                Vector2(
+                    (center.x + radius * kotlin.math.cos(angle)).toFloat(),
+                    (center.y + radius * kotlin.math.sin(angle)).toFloat(),
+                )
+            }
+            return PolygonBuilder(vertices = points.toMutableList(), drawMode = drawMode).close()
+        }
+
     }
 }
 

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonFactoryTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonFactoryTest.kt
@@ -1,0 +1,34 @@
+package life.sim.simulator.rendering.geometry
+
+import com.badlogic.gdx.math.Vector2
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PolygonFactoryTest {
+    @Test
+    fun `rect creates a closed four-corner polygon`() {
+        val polygon = Polygon.rect(10f, 20f, 30f, 40f)
+
+        assertEquals(Vector2(10f, 20f), polygon.vertices.first())
+        assertEquals(Vector2(10f, 20f), polygon.vertices.last())
+        assertEquals(5, polygon.vertices.size)
+    }
+
+    @Test
+    fun `triangle creates a closed triangle polygon`() {
+        val polygon = Polygon.triangle(Vector2(0f, 0f), Vector2(10f, 0f), Vector2(5f, 8f))
+
+        assertEquals(4, polygon.vertices.size)
+        assertEquals(polygon.vertices.first(), polygon.vertices.last())
+    }
+
+    @Test
+    fun `circle creates closed approximation with requested segments`() {
+        val polygon = Polygon.circle(Vector2(0f, 0f), radius = 5f, segments = 12)
+
+        assertEquals(13, polygon.vertices.size)
+        assertEquals(polygon.vertices.first(), polygon.vertices.last())
+        assertTrue(polygon.vertices.dropLast(1).all { point -> kotlin.math.abs(point.len() - 5f) < 0.0001f })
+    }
+}

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonFactoryTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonFactoryTest.kt
@@ -3,6 +3,7 @@ package life.sim.simulator.rendering.geometry
 import com.badlogic.gdx.math.Vector2
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class PolygonFactoryTest {
@@ -24,11 +25,19 @@ class PolygonFactoryTest {
     }
 
     @Test
-    fun `circle creates closed approximation with requested segments`() {
-        val polygon = Polygon.circle(Vector2(0f, 0f), radius = 5f, segments = 12)
+    fun `circle creates closed approximation with requested segments around provided center`() {
+        val center = Vector2(3f, -4f)
+        val polygon = Polygon.circle(center, radius = 5f, segments = 12)
 
         assertEquals(13, polygon.vertices.size)
         assertEquals(polygon.vertices.first(), polygon.vertices.last())
-        assertTrue(polygon.vertices.dropLast(1).all { point -> kotlin.math.abs(point.len() - 5f) < 0.0001f })
+        assertTrue(polygon.vertices.dropLast(1).all { point -> kotlin.math.abs(point.dst(center) - 5f) < 0.0001f })
+    }
+
+    @Test
+    fun `circle rejects non-positive radius`() {
+        assertFailsWith<IllegalArgumentException> {
+            Polygon.circle(Vector2(0f, 0f), radius = 0f, segments = 12)
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Provide small, reusable constructors for common polygon shapes to simplify building polygon-based geometry and to make downstream renderer changes easier.

### Description

- Add `Polygon.rect(x, y, width, height, drawMode)` to create a closed rectangular `Polygon` in `Polygon.Companion`.
- Add `Polygon.triangle(a, b, c, drawMode)` to create a closed triangular `Polygon` in `Polygon.Companion`.
- Add `Polygon.circle(center, radius, segments = 24, drawMode)` to approximate a closed circle (requires `segments >= 3`).
- Persist changes to `simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt` and add tests in `simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonFactoryTest.kt` that validate closure, vertex counts, and circle radius consistency.

### Testing

- Ran `./gradlew :simulator:test --tests "life.sim.simulator.rendering.geometry.PolygonFactoryTest"` and the task completed successfully (BUILD SUCCESSFUL).
- The new `PolygonFactoryTest` suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32877c8988329b716ae2df16f4fd4)