### PR TITLE
Complete geometry refactor: ordered GeometryElement model with self-rendering Polygons

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,8 @@
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -12,6 +16,24 @@ allprojects {
 }
 
 subprojects {
+    plugins.withId("java") {
+        extensions.configure<JavaPluginExtension> {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(21))
+            }
+        }
+
+        tasks.withType<JavaCompile>().configureEach {
+            options.release.set(21)
+        }
+    }
+
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        extensions.configure<KotlinJvmProjectExtension> {
+            jvmToolchain(21)
+        }
+    }
+
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = "life-sim"
 
 include("biology")

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -123,9 +123,15 @@ Planned follow-up work includes:
 ### Geometry and polygon rendering
 
 Simulator rendering geometry is centralized in `rendering/geometry` so shapes, bounds rules, and construction helpers evolve together.
-`Geometry.render(...)` now supports polygon lists in addition to rects/triangles/arcs/lines, and `RenderContext` can draw filled or wireframe polygons from raw vertex data.
+`Geometry` is now an ordered list of `GeometryElement`s, and `Geometry.render(context)` draws those elements in list order (front-to-back layering is caller-controlled).
+Each element owns its style (for example `color` and arc `lineWidth`) and calls the corresponding `RenderContext` draw method.
 
-For complex connectors, use `Polygon.of(...).add(...).close()` and `arc(start, center, end, segments, sweepDirection)` to approximate curved edges as vertices.
+Use shape helpers for common cases:
+- `Polygon.rect(...)` / `Polygon.triangle(...)` for filled polygons with explicit color.
+- `Arc(..., lineWidth = 0f)` for filled arcs; positive `lineWidth` renders stroked arcs.
+- `Line(...)` for explicit line segments.
+
+For complex connectors, use `Polygon.of(color = ...).add(...).close()` and `arc(start, center, end, segments, sweepDirection)` to approximate curved edges as vertices.
 Filled polygons are triangulated from that outline data before rendering, so curved and concave silhouettes do not need to be authored as triangle fans by hand.
 Set `sweepDirection` explicitly when `start` and `end` sit opposite each other on a diameter, because those points alone do not determine which side of the circle should be traced.
 This keeps awkward silhouettes composable and prepares the pipeline for later startup-time sprite generation.

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -186,6 +186,7 @@ class NucleotideRenderer(
                 90f,
                 180f,
                 color,
+                lineWidth = 0f,
             )
 
             PairingSide.RIGHT -> Arc(
@@ -195,6 +196,7 @@ class NucleotideRenderer(
                 -90f,
                 180f,
                 color,
+                lineWidth = 0f,
             )
 
             PairingSide.TOP -> Arc(
@@ -204,6 +206,7 @@ class NucleotideRenderer(
                 0f,
                 180f,
                 color,
+                lineWidth = 0f,
             )
 
             PairingSide.BOTTOM -> Arc(
@@ -213,6 +216,7 @@ class NucleotideRenderer(
                 -180f,
                 180f,
                 color,
+                lineWidth = 0f,
             )
         }
     }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -79,23 +79,63 @@ class NucleotideRenderer(
         val y = position.y
         return when (side) {
             PairingSide.TOP -> listOf(
-                Polygon.triangle(Vector2(x, y + baseSize), Vector2(x, y + baseSize + pairingBandSize), Vector2(x + baseSize * 0.5f, y + baseSize), color = color),
-                Polygon.triangle(Vector2(x + baseSize * 0.5f, y + baseSize), Vector2(x + baseSize, y + baseSize + pairingBandSize), Vector2(x + baseSize, y + baseSize), color = color),
+                Polygon.triangle(
+                    Vector2(x, y + baseSize),
+                    Vector2(x, y + baseSize + pairingBandSize),
+                    Vector2(x + baseSize * 0.5f, y + baseSize),
+                    color = color
+                ),
+                Polygon.triangle(
+                    Vector2(x + baseSize * 0.5f, y + baseSize),
+                    Vector2(x + baseSize, y + baseSize + pairingBandSize),
+                    Vector2(x + baseSize, y + baseSize),
+                    color = color
+                ),
             )
 
             PairingSide.BOTTOM -> listOf(
-                Polygon.triangle(Vector2(x, y), Vector2(x + baseSize * 0.5f, y), Vector2(x, y - pairingBandSize), color = color),
-                Polygon.triangle(Vector2(x + baseSize * 0.5f, y), Vector2(x + baseSize, y), Vector2(x + baseSize, y - pairingBandSize), color = color),
+                Polygon.triangle(
+                    Vector2(x, y),
+                    Vector2(x + baseSize * 0.5f, y),
+                    Vector2(x, y - pairingBandSize),
+                    color = color
+                ),
+                Polygon.triangle(
+                    Vector2(x + baseSize * 0.5f, y),
+                    Vector2(x + baseSize, y),
+                    Vector2(x + baseSize, y - pairingBandSize),
+                    color = color
+                ),
             )
 
             PairingSide.LEFT -> listOf(
-                Polygon.triangle(Vector2(x, y + baseSize), Vector2(x, y + baseSize * 0.5f), Vector2(x - pairingBandSize, y + baseSize), color = color),
-                Polygon.triangle(Vector2(x, y + baseSize * 0.5f), Vector2(x, y), Vector2(x - pairingBandSize, y), color = color),
+                Polygon.triangle(
+                    Vector2(x, y + baseSize),
+                    Vector2(x, y + baseSize * 0.5f),
+                    Vector2(x - pairingBandSize, y + baseSize),
+                    color = color
+                ),
+                Polygon.triangle(
+                    Vector2(x, y + baseSize * 0.5f),
+                    Vector2(x, y),
+                    Vector2(x - pairingBandSize, y),
+                    color = color
+                ),
             )
 
             PairingSide.RIGHT -> listOf(
-                Polygon.triangle(Vector2(x + baseSize, y + baseSize), Vector2(x + baseSize + pairingBandSize, y + baseSize), Vector2(x + baseSize, y + baseSize * 0.5f), color = color),
-                Polygon.triangle(Vector2(x + baseSize, y + baseSize * 0.5f), Vector2(x + baseSize + pairingBandSize, y), Vector2(x + baseSize, y), color = color),
+                Polygon.triangle(
+                    Vector2(x + baseSize, y + baseSize),
+                    Vector2(x + baseSize + pairingBandSize, y + baseSize),
+                    Vector2(x + baseSize, y + baseSize * 0.5f),
+                    color = color
+                ),
+                Polygon.triangle(
+                    Vector2(x + baseSize, y + baseSize * 0.5f),
+                    Vector2(x + baseSize + pairingBandSize, y),
+                    Vector2(x + baseSize, y),
+                    color = color
+                ),
             )
         }
     }
@@ -104,13 +144,33 @@ class NucleotideRenderer(
         val x = position.x
         val y = position.y
         return when (side) {
-            PairingSide.LEFT -> Polygon.triangle(Vector2(x, y), Vector2(x, y + baseSize), Vector2(x - pairingBandSize, y + baseSize * 0.5f), color = color)
+            PairingSide.LEFT -> Polygon.triangle(
+                Vector2(x, y),
+                Vector2(x, y + baseSize),
+                Vector2(x - pairingBandSize, y + baseSize * 0.5f),
+                color = color
+            )
 
-            PairingSide.RIGHT -> Polygon.triangle(Vector2(x + baseSize, y), Vector2(x + baseSize + pairingBandSize, y + baseSize * 0.5f), Vector2(x + baseSize, y + baseSize), color = color)
+            PairingSide.RIGHT -> Polygon.triangle(
+                Vector2(x + baseSize, y),
+                Vector2(x + baseSize + pairingBandSize, y + baseSize * 0.5f),
+                Vector2(x + baseSize, y + baseSize),
+                color = color
+            )
 
-            PairingSide.TOP -> Polygon.triangle(Vector2(x, y + baseSize), Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize), Vector2(x + baseSize, y + baseSize), color = color)
+            PairingSide.TOP -> Polygon.triangle(
+                Vector2(x, y + baseSize),
+                Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize),
+                Vector2(x + baseSize, y + baseSize),
+                color = color
+            )
 
-            PairingSide.BOTTOM -> Polygon.triangle(Vector2(x, y), Vector2(x + baseSize, y), Vector2(x + baseSize * 0.5f, y - pairingBandSize), color = color)
+            PairingSide.BOTTOM -> Polygon.triangle(
+                Vector2(x, y),
+                Vector2(x + baseSize, y),
+                Vector2(x + baseSize * 0.5f, y - pairingBandSize),
+                color = color
+            )
         }
     }
 
@@ -126,7 +186,6 @@ class NucleotideRenderer(
                 90f,
                 180f,
                 color,
-                baseSize * 0.08f,
             )
 
             PairingSide.RIGHT -> Arc(
@@ -136,7 +195,6 @@ class NucleotideRenderer(
                 -90f,
                 180f,
                 color,
-                baseSize * 0.08f,
             )
 
             PairingSide.TOP -> Arc(
@@ -146,7 +204,6 @@ class NucleotideRenderer(
                 0f,
                 180f,
                 color,
-                baseSize * 0.08f,
             )
 
             PairingSide.BOTTOM -> Arc(
@@ -156,7 +213,6 @@ class NucleotideRenderer(
                 -180f,
                 180f,
                 color,
-                baseSize * 0.08f,
             )
         }
     }
@@ -173,9 +229,9 @@ class NucleotideRenderer(
             )
                 .add(
                     arc(
-                        Vector2(x - pairingBandSize, y + baseSize),
-                        Vector2(x - pairingBandSize, y + baseSize * 0.5f),
-                        Vector2(x - pairingBandSize, y),
+                        start = Vector2(x - pairingBandSize, y + baseSize),
+                        center = Vector2(x - pairingBandSize, y + baseSize * 0.5f),
+                        end = Vector2(x - pairingBandSize, y),
                         segments = 10,
                         sweepDirection = ArcSweepDirection.CLOCKWISE,
                     ),
@@ -194,9 +250,9 @@ class NucleotideRenderer(
             )
                 .add(
                     arc(
-                        Vector2(x + baseSize + pairingBandSize, y + baseSize),
-                        Vector2(x + baseSize + pairingBandSize, y + baseSize * 0.5f),
-                        Vector2(x + baseSize + pairingBandSize, y),
+                        start = Vector2(x + baseSize + pairingBandSize, y + baseSize),
+                        center = Vector2(x + baseSize + pairingBandSize, y + baseSize * 0.5f),
+                        end = Vector2(x + baseSize + pairingBandSize, y),
                         segments = 10,
                         sweepDirection = ArcSweepDirection.COUNTERCLOCKWISE,
                     ),
@@ -216,9 +272,9 @@ class NucleotideRenderer(
             )
                 .add(
                     arc(
-                        Vector2(x + baseSize, y + baseSize + pairingBandSize),
-                        Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize),
-                        Vector2(x, y + baseSize + pairingBandSize),
+                        start =Vector2(x + baseSize, y + baseSize + pairingBandSize),
+                        center = Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize),
+                        end = Vector2(x, y + baseSize + pairingBandSize),
                         segments = 10,
                         sweepDirection = ArcSweepDirection.CLOCKWISE,
                     ),
@@ -226,21 +282,22 @@ class NucleotideRenderer(
                 .add(Vector2(x, y + baseSize))
                 .close()
 
-            PairingSide.BOTTOM -> Polygon.of(
-                Vector2(x + baseSize, y + baseSize),
-                Vector2(x, y + baseSize),
-                Vector2(x, y),
-                Vector2(x, y - pairingBandSize),
-                color = color,
-            )
+            PairingSide.BOTTOM -> Polygon
+                .of(
+                    Vector2(x + baseSize, y + baseSize),
+                    Vector2(x, y + baseSize),
+                    Vector2(x, y),
+                    Vector2(x, y - pairingBandSize),
+                    color = color
+                )
                 .add(
                     arc(
-                        Vector2(x, y - pairingBandSize),
-                        Vector2(x + baseSize * 0.5f, y - pairingBandSize),
-                        Vector2(x + baseSize, y - pairingBandSize),
+                        start = Vector2(x, y - pairingBandSize),
+                        center = Vector2(x + baseSize * 0.5f, y - pairingBandSize),
+                        end = Vector2(x + baseSize, y - pairingBandSize),
                         segments = 10,
                         sweepDirection = ArcSweepDirection.CLOCKWISE,
-                    ),
+                    )
                 )
                 .add(Vector2(x + baseSize, y))
                 .close()

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -53,20 +53,20 @@ class NucleotideRenderer(
         when (profile.family) {
             ConnectorFamily.ANGLED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
-                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color)
-                    elements += triangleOnSide(position, orientation.pairingSide, color)
+                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color.cpy())
+                    elements += triangleOnSide(position, orientation.pairingSide, color.cpy())
                 } else {
-                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color)
-                    elements += inverseTriangleOnSide(position, orientation.pairingSide, color)
+                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color.cpy())
+                    elements += inverseTriangleOnSide(position, orientation.pairingSide, color.cpy())
                 }
             }
 
             ConnectorFamily.ROUNDED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
-                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color)
-                    elements += roundedOnSide(position, orientation.pairingSide, color)
+                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color.cpy())
+                    elements += roundedOnSide(position, orientation.pairingSide, color.cpy())
                 } else {
-                    elements += roundedSocketPolygonOnSide(position, orientation.pairingSide, color)
+                    elements += roundedSocketPolygonOnSide(position, orientation.pairingSide, color.cpy())
                 }
             }
         }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -23,7 +23,7 @@ class NucleotideRenderer(
     }
 
     fun render(value: Nucleotide, position: Vector2, context: RenderContext, orientation: NucleotideOrientation) {
-        geometryFor(value, position, orientation).render(context, nucleotideColor(value))
+        geometryFor(value, position, orientation, nucleotideColor(value)).render(context)
         context.drawCenteredText(value.symbol.toString(), position.x + baseSize * 0.5f, position.y + baseSize * 0.5f)
     }
 
@@ -45,173 +45,76 @@ class NucleotideRenderer(
         nucleotide: Nucleotide,
         position: Vector2,
         orientation: NucleotideOrientation,
+        color: Color = nucleotideColor(nucleotide),
     ): Geometry {
         val profile = connectorProfile(nucleotide)
-        val filledTriangles = mutableListOf<Triangle>()
-        val filledRects = mutableListOf<Rect>()
-        val filledArcs = mutableListOf<Arc>()
-        val arcs = mutableListOf<Arc>()
-        val triangles = mutableListOf<Triangle>()
-        val lines = mutableListOf<Line>()
-        val polygons = mutableListOf<Polygon>()
+        val elements = mutableListOf<GeometryElement>()
 
         when (profile.family) {
             ConnectorFamily.ANGLED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
-                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
-                    filledTriangles += triangleOnSide(position, orientation.pairingSide)
+                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color)
+                    elements += triangleOnSide(position, orientation.pairingSide, color)
                 } else {
-                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
-                    filledTriangles += inverseTriangleOnSide(position, orientation.pairingSide)
+                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color)
+                    elements += inverseTriangleOnSide(position, orientation.pairingSide, color)
                 }
             }
 
             ConnectorFamily.ROUNDED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
-                    filledRects += Rect(position.x, position.y, baseSize, baseSize)
-                    filledArcs += roundedOnSide(position, orientation.pairingSide)
+                    elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color)
+                    elements += roundedOnSide(position, orientation.pairingSide, color)
                 } else {
-                    polygons += roundedSocketPolygonOnSide(position, orientation.pairingSide)
+                    elements += roundedSocketPolygonOnSide(position, orientation.pairingSide, color)
                 }
             }
         }
 
-        return Geometry(
-            filledTriangles = filledTriangles,
-            filledRects = filledRects,
-            filledArcs = filledArcs,
-            arcs = arcs,
-            triangles = triangles,
-            lines = lines,
-            polygons = polygons,
-        )
+        return Geometry(elements)
     }
 
-    private fun inverseTriangleOnSide(position: Vector2, side: PairingSide): List<Triangle> {
+    private fun inverseTriangleOnSide(position: Vector2, side: PairingSide, color: Color): List<Polygon> {
         val x = position.x
         val y = position.y
         return when (side) {
             PairingSide.TOP -> listOf(
-                Triangle(
-                    x,
-                    y + baseSize,
-                    x,
-                    y + baseSize + pairingBandSize,
-                    x + baseSize * 0.5f,
-                    y + baseSize,
-                ),
-                Triangle(
-                    x + baseSize * 0.5f,
-                    y + baseSize,
-                    x + baseSize,
-                    y + baseSize + pairingBandSize,
-                    x + baseSize,
-                    y + baseSize,
-                ),
+                Polygon.triangle(Vector2(x, y + baseSize), Vector2(x, y + baseSize + pairingBandSize), Vector2(x + baseSize * 0.5f, y + baseSize), color = color),
+                Polygon.triangle(Vector2(x + baseSize * 0.5f, y + baseSize), Vector2(x + baseSize, y + baseSize + pairingBandSize), Vector2(x + baseSize, y + baseSize), color = color),
             )
 
             PairingSide.BOTTOM -> listOf(
-                Triangle(
-                    x,
-                    y,
-                    x + baseSize * 0.5f,
-                    y,
-                    x,
-                    y - pairingBandSize,
-                ),
-                Triangle(
-                    x + baseSize * 0.5f,
-                    y,
-                    x + baseSize,
-                    y,
-                    x + baseSize,
-                    y - pairingBandSize,
-                ),
+                Polygon.triangle(Vector2(x, y), Vector2(x + baseSize * 0.5f, y), Vector2(x, y - pairingBandSize), color = color),
+                Polygon.triangle(Vector2(x + baseSize * 0.5f, y), Vector2(x + baseSize, y), Vector2(x + baseSize, y - pairingBandSize), color = color),
             )
 
             PairingSide.LEFT -> listOf(
-                Triangle(
-                    x,
-                    y + baseSize,
-                    x,
-                    y + baseSize * 0.5f,
-                    x - pairingBandSize,
-                    y + baseSize,
-                ),
-                Triangle(
-                    x,
-                    y + baseSize * 0.5f,
-                    x,
-                    y,
-                    x - pairingBandSize,
-                    y,
-                ),
+                Polygon.triangle(Vector2(x, y + baseSize), Vector2(x, y + baseSize * 0.5f), Vector2(x - pairingBandSize, y + baseSize), color = color),
+                Polygon.triangle(Vector2(x, y + baseSize * 0.5f), Vector2(x, y), Vector2(x - pairingBandSize, y), color = color),
             )
 
             PairingSide.RIGHT -> listOf(
-                Triangle(
-                    x + baseSize,
-                    y + baseSize,
-                    x + baseSize + pairingBandSize,
-                    y + baseSize,
-                    x + baseSize,
-                    y + baseSize * 0.5f,
-                ),
-                Triangle(
-                    x + baseSize,
-                    y + baseSize * 0.5f,
-                    x + baseSize + pairingBandSize,
-                    y,
-                    x + baseSize,
-                    y,
-                ),
+                Polygon.triangle(Vector2(x + baseSize, y + baseSize), Vector2(x + baseSize + pairingBandSize, y + baseSize), Vector2(x + baseSize, y + baseSize * 0.5f), color = color),
+                Polygon.triangle(Vector2(x + baseSize, y + baseSize * 0.5f), Vector2(x + baseSize + pairingBandSize, y), Vector2(x + baseSize, y), color = color),
             )
         }
     }
 
-    private fun triangleOnSide(position: Vector2, side: PairingSide): Triangle {
+    private fun triangleOnSide(position: Vector2, side: PairingSide, color: Color): Polygon {
         val x = position.x
         val y = position.y
         return when (side) {
-            PairingSide.LEFT -> Triangle(
-                x,
-                y,
-                x,
-                y + baseSize,
-                x - pairingBandSize,
-                y + baseSize * 0.5f,
-            )
+            PairingSide.LEFT -> Polygon.triangle(Vector2(x, y), Vector2(x, y + baseSize), Vector2(x - pairingBandSize, y + baseSize * 0.5f), color = color)
 
-            PairingSide.RIGHT -> Triangle(
-                x + baseSize,
-                y,
-                x + baseSize + pairingBandSize,
-                y + baseSize * 0.5f,
-                x + baseSize,
-                y + baseSize,
-            )
+            PairingSide.RIGHT -> Polygon.triangle(Vector2(x + baseSize, y), Vector2(x + baseSize + pairingBandSize, y + baseSize * 0.5f), Vector2(x + baseSize, y + baseSize), color = color)
 
-            PairingSide.TOP -> Triangle(
-                x,
-                y + baseSize,
-                x + baseSize * 0.5f,
-                y + baseSize + pairingBandSize,
-                x + baseSize,
-                y + baseSize,
-            )
+            PairingSide.TOP -> Polygon.triangle(Vector2(x, y + baseSize), Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize), Vector2(x + baseSize, y + baseSize), color = color)
 
-            PairingSide.BOTTOM -> Triangle(
-                x,
-                y,
-                x + baseSize,
-                y,
-                x + baseSize * 0.5f,
-                y - pairingBandSize,
-            )
+            PairingSide.BOTTOM -> Polygon.triangle(Vector2(x, y), Vector2(x + baseSize, y), Vector2(x + baseSize * 0.5f, y - pairingBandSize), color = color)
         }
     }
 
-    private fun roundedOnSide(position: Vector2, side: PairingSide): Arc {
+    private fun roundedOnSide(position: Vector2, side: PairingSide, color: Color): Arc {
         val x = position.x
         val y = position.y
         val capRadius = baseSize * 0.5f
@@ -222,6 +125,7 @@ class NucleotideRenderer(
                 capRadius,
                 90f,
                 180f,
+                color,
                 baseSize * 0.08f,
             )
 
@@ -231,6 +135,7 @@ class NucleotideRenderer(
                 capRadius,
                 -90f,
                 180f,
+                color,
                 baseSize * 0.08f,
             )
 
@@ -240,6 +145,7 @@ class NucleotideRenderer(
                 capRadius,
                 0f,
                 180f,
+                color,
                 baseSize * 0.08f,
             )
 
@@ -249,12 +155,13 @@ class NucleotideRenderer(
                 capRadius,
                 -180f,
                 180f,
+                color,
                 baseSize * 0.08f,
             )
         }
     }
 
-    private fun roundedSocketPolygonOnSide(position: Vector2, side: PairingSide): Polygon {
+    private fun roundedSocketPolygonOnSide(position: Vector2, side: PairingSide, color: Color): Polygon {
         val x = position.x
         val y = position.y
         return when (side) {
@@ -262,6 +169,7 @@ class NucleotideRenderer(
                 Vector2(x + baseSize, y + baseSize),
                 Vector2(x, y + baseSize),
                 Vector2(x - pairingBandSize, y + baseSize),
+                color = color,
             )
                 .add(
                     arc(
@@ -282,6 +190,7 @@ class NucleotideRenderer(
                 Vector2(x, y + baseSize),
                 Vector2(x + baseSize, y + baseSize),
                 Vector2(x + baseSize + pairingBandSize, y + baseSize),
+                color = color,
             )
                 .add(
                     arc(
@@ -303,6 +212,7 @@ class NucleotideRenderer(
                 Vector2(x + baseSize, y),
                 Vector2(x + baseSize, y + baseSize),
                 Vector2(x + baseSize, y + baseSize + pairingBandSize),
+                color = color,
             )
                 .add(
                     arc(
@@ -321,6 +231,7 @@ class NucleotideRenderer(
                 Vector2(x, y + baseSize),
                 Vector2(x, y),
                 Vector2(x, y - pairingBandSize),
+                color = color,
             )
                 .add(
                     arc(
@@ -375,4 +286,3 @@ enum class PairingSide {
     TOP,
     BOTTOM,
 }
-

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Arc.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Arc.kt
@@ -1,5 +1,7 @@
 package life.sim.simulator.rendering.geometry
 
+import com.badlogic.gdx.graphics.Color
+import life.sim.simulator.rendering.RenderContext
 import life.sim.simulator.rendering.ShapeBounds
 import kotlin.math.PI
 import kotlin.math.abs
@@ -16,8 +18,17 @@ internal data class Arc(
     val radius: Float,
     val startDegrees: Float,
     val degrees: Float,
+    val color: Color,
     val lineWidth: Float = 0f,
-)
+) : GeometryElement {
+    override fun render(context: RenderContext) {
+        if (lineWidth <= 0f) {
+            context.drawFilledArc(x, y, radius, startDegrees, degrees, color)
+        } else {
+            context.drawArc(x, y, radius, startDegrees, degrees, color, lineWidth)
+        }
+    }
+}
 
 internal fun Arc.bounds(includeCenter: Boolean = false, includeStroke: Boolean = false): ShapeBounds {
     val strokePadding = if (includeStroke) {
@@ -109,4 +120,3 @@ private fun normalizeAngle(angle: Float): Float {
         normalized
     }
 }
-

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Arc.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Arc.kt
@@ -21,6 +21,9 @@ internal data class Arc(
     val color: Color,
     val lineWidth: Float = 0f,
 ) : GeometryElement {
+    init {
+        require(lineWidth >= 0f) { "lineWidth must be >= 0." }
+    }
     override fun render(context: RenderContext) {
         if (lineWidth <= 0f) {
             context.drawFilledArc(x, y, radius, startDegrees, degrees, color)

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Geometry.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Geometry.kt
@@ -1,39 +1,13 @@
 package life.sim.simulator.rendering.geometry
 
-import com.badlogic.gdx.graphics.Color
 import life.sim.simulator.rendering.RenderContext
 
 internal data class Geometry(
-    val filledTriangles: List<Triangle>,
-    val filledRects: List<Rect>,
-    val filledArcs: List<Arc>,
-    val arcs: List<Arc>,
-    val triangles: List<Triangle>,
-    val lines: List<Line>,
-    val polygons: List<Polygon>,
-)
-
-internal fun Geometry.render(context: RenderContext, color: Color) {
-    this.filledRects.forEach { rect ->
-        context.drawFilledRect(rect.x, rect.y, rect.width, rect.height, color)
-    }
-    this.filledTriangles.forEach { triangle ->
-        context.drawFilledTriangle(triangle.x1, triangle.y1, triangle.x2, triangle.y2, triangle.x3, triangle.y3, color)
-    }
-    this.filledArcs.forEach { arc ->
-        context.drawFilledArc(arc.x, arc.y, arc.radius, arc.startDegrees, arc.degrees, color)
-    }
-    this.arcs.forEach { arc ->
-        context.drawArc(arc.x, arc.y, arc.radius, arc.startDegrees, arc.degrees, color, arc.lineWidth)
-    }
-    this.triangles.forEach { triangle ->
-        context.drawTriangle(triangle.x1, triangle.y1, triangle.x2, triangle.y2, triangle.x3, triangle.y3, color)
-    }
-    this.lines.forEach { line ->
-        context.drawLine(line.a, line.b, line.width, color)
-    }
-    this.polygons.forEach { polygon ->
-        context.drawPolygon(polygon.vertices, polygon.drawMode, color)
-    }
+    val elements: List<GeometryElement>,
+) {
+    constructor(vararg elements: GeometryElement) : this(elements.toList())
 }
 
+internal fun Geometry.render(context: RenderContext) {
+    this.elements.forEach { element -> element.render(context) }
+}

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/GeometryElement.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/GeometryElement.kt
@@ -1,0 +1,7 @@
+package life.sim.simulator.rendering.geometry
+
+import life.sim.simulator.rendering.RenderContext
+
+internal interface GeometryElement {
+    fun render(context: RenderContext)
+}

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Line.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Line.kt
@@ -1,10 +1,16 @@
 package life.sim.simulator.rendering.geometry
 
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.math.Vector2
+import life.sim.simulator.rendering.RenderContext
 
 internal data class Line(
     val a: Vector2,
     val b: Vector2,
     val width: Float,
-)
-
+    val color: Color,
+) : GeometryElement {
+    override fun render(context: RenderContext) {
+        context.drawLine(a, b, width, color)
+    }
+}

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/geometry/Polygon.kt
@@ -1,7 +1,9 @@
 package life.sim.simulator.rendering.geometry
 
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.math.EarClippingTriangulator
 import com.badlogic.gdx.math.Vector2
+import life.sim.simulator.rendering.RenderContext
 
 internal enum class PolygonDrawMode {
     FILLED,
@@ -15,25 +17,31 @@ internal enum class ArcSweepDirection {
 
 internal data class Polygon(
     val vertices: List<Vector2>,
+    val color: Color,
     val drawMode: PolygonDrawMode,
-) {
-    companion object {
-        fun of(vararg vertices: Vector2, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): PolygonBuilder =
-            PolygonBuilder(vertices = vertices.toList().map(Vector2::cpy).toMutableList(), drawMode = drawMode)
+) : GeometryElement {
+    override fun render(context: RenderContext) {
+        context.drawPolygon(vertices, drawMode, color)
+    }
 
-        fun rect(x: Float, y: Float, width: Float, height: Float, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon =
+    companion object {
+        fun of(vararg vertices: Vector2, color: Color, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): PolygonBuilder =
+            PolygonBuilder(vertices = vertices.toList().map(Vector2::cpy).toMutableList(), color = color, drawMode = drawMode)
+
+        fun rect(x: Float, y: Float, width: Float, height: Float, color: Color, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon =
             of(
                 Vector2(x, y),
                 Vector2(x + width, y),
                 Vector2(x + width, y + height),
                 Vector2(x, y + height),
+                color = color,
                 drawMode = drawMode,
             ).close()
 
-        fun triangle(a: Vector2, b: Vector2, c: Vector2, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon =
-            of(a, b, c, drawMode = drawMode).close()
+        fun triangle(a: Vector2, b: Vector2, c: Vector2, color: Color, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon =
+            of(a, b, c, color = color, drawMode = drawMode).close()
 
-        fun circle(center: Vector2, radius: Float, segments: Int = 24, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon {
+        fun circle(center: Vector2, radius: Float, color: Color, segments: Int = 24, drawMode: PolygonDrawMode = PolygonDrawMode.FILLED): Polygon {
             require(segments >= 3) { "segments must be >= 3." }
             require(radius > 0f) { "radius must be > 0." }
             val points = (0 until segments).map { i ->
@@ -43,7 +51,7 @@ internal data class Polygon(
                     (center.y + radius * kotlin.math.sin(angle)).toFloat(),
                 )
             }
-            return PolygonBuilder(vertices = points.toMutableList(), drawMode = drawMode).close()
+            return PolygonBuilder(vertices = points.toMutableList(), color = color, drawMode = drawMode).close()
         }
 
     }
@@ -51,6 +59,7 @@ internal data class Polygon(
 
 internal class PolygonBuilder internal constructor(
     private val vertices: MutableList<Vector2>,
+    private val color: Color,
     private val drawMode: PolygonDrawMode,
 ) {
     fun add(vararg points: Vector2): PolygonBuilder {
@@ -68,20 +77,10 @@ internal class PolygonBuilder internal constructor(
         if (closedVertices.size > 2 && closedVertices.first() != closedVertices.last()) {
             closedVertices += closedVertices.first().cpy()
         }
-        return Polygon(vertices = closedVertices, drawMode = drawMode)
+        return Polygon(vertices = closedVertices, color = color, drawMode = drawMode)
     }
 }
 
-/**
- * Generates an arc from `start` to `end` around `center`.
- *
- * The radius is taken from the distance between `start` and `center`, and the returned list contains
- * `segments + 1` evenly spaced points including the generated start and final arc point.
- *
- * `sweepDirection` controls which side of the circle is traced when `start` and `end` alone are ambiguous,
- * such as opposite points on the same diameter. The final point coincides with `end` only when `end` lies on
- * that same circle.
- */
 internal fun arc(
     start: Vector2,
     center: Vector2,
@@ -148,4 +147,3 @@ internal fun polygonOutline(vertices: List<Vector2>): List<Vector2> =
     } else {
         vertices
     }
-

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
@@ -1,5 +1,6 @@
 package life.sim.simulator.rendering
 
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.math.Vector2
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -58,22 +59,15 @@ class NucleotideRendererTest {
     fun `isWithinNucleotideGeometryTestWindow accepts outline arcs that only sweep inside the tile`() {
         val origin = Vector2(0f, 0f)
         val geometry = Geometry(
-            filledTriangles = emptyList(),
-            filledRects = emptyList(),
-            filledArcs = emptyList(),
-            arcs = listOf(
-                Arc(
-                    x = origin.x - renderer.baseSize * 0.75f + 1.5f,
-                    y = origin.y,
-                    radius = 10f,
-                    startDegrees = -90f,
-                    degrees = 180f,
-                    lineWidth = 3f,
-                ),
+            Arc(
+                x = origin.x - renderer.baseSize * 0.75f + 1.5f,
+                y = origin.y,
+                radius = 10f,
+                startDegrees = -90f,
+                degrees = 180f,
+                color = Color.WHITE,
+                lineWidth = 3f,
             ),
-            triangles = emptyList(),
-            lines = emptyList(),
-            polygons = emptyList(),
         )
 
         assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin))
@@ -83,22 +77,15 @@ class NucleotideRendererTest {
     fun `isWithinNucleotideGeometryTestWindow accepts filled arcs that only sweep inside the tile`() {
         val origin = Vector2(0f, 0f)
         val geometry = Geometry(
-            filledTriangles = emptyList(),
-            filledRects = emptyList(),
-            filledArcs = listOf(
-                Arc(
-                    x = origin.x,
-                    y = origin.y - renderer.baseSize * 0.75f,
-                    radius = 10f,
-                    startDegrees = 0f,
-                    degrees = 180f,
-                    lineWidth = 3f,
-                ),
+            Arc(
+                x = origin.x,
+                y = origin.y - renderer.baseSize * 0.75f,
+                radius = 10f,
+                startDegrees = 0f,
+                degrees = 180f,
+                color = Color.WHITE,
+                lineWidth = 0f,
             ),
-            arcs = emptyList(),
-            triangles = emptyList(),
-            lines = emptyList(),
-            polygons = emptyList(),
         )
 
         assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin))
@@ -116,9 +103,9 @@ class NucleotideRendererTest {
 
         listOf(PairingSide.LEFT, PairingSide.RIGHT, PairingSide.TOP, PairingSide.BOTTOM).forEach { pairingSide ->
             val geometry = renderer.geometryFor(Nucleotide.G, origin, NucleotideOrientation(pairingSide))
-            val polygon = geometry.polygons.single()
+            val polygon = geometry.elements.filterIsInstance<Polygon>().single()
 
-            assertEquals(emptyList(), geometry.filledRects)
+            assertTrue(geometry.elements.none { it is Arc || it is Line })
             assertTrue(baseCorners.all(polygon.vertices::contains), "Expected the rounded indentation polygon to keep the rectangular body corners")
             assertTrue(polygon.vertices.first() == polygon.vertices.last(), "Expected the rounded indentation polygon to be closed")
             assertTrue(polygonArea(polygon.vertices) > renderer.baseSize * renderer.baseSize, "Expected the rounded indentation polygon to cover more area than the base square")
@@ -166,52 +153,16 @@ class NucleotideRendererTest {
         val minY = position.y - renderer.baseSize * 0.75f
         val maxY = position.y + renderer.baseSize * 1.75f
 
-        val rectsInBounds = geometry.filledRects.all { rect ->
-            rect.x >= minX &&
-                rect.y >= minY &&
-                rect.x + rect.width <= maxX &&
-                rect.y + rect.height <= maxY
-        }
-
-        if (!rectsInBounds) return false
-
-        val filledTrianglesInBounds = geometry.filledTriangles.all { triangle ->
-            val xs = listOf(triangle.x1, triangle.x2, triangle.x3)
-            val ys = listOf(triangle.y1, triangle.y2, triangle.y3)
-            xs.all { it in minX..maxX } && ys.all { it in minY..maxY }
-        }
-
-        if (!filledTrianglesInBounds) return false
-
-        val trianglesInBounds = geometry.triangles.all { triangle ->
-            val xs = listOf(triangle.x1, triangle.x2, triangle.x3)
-            val ys = listOf(triangle.y1, triangle.y2, triangle.y3)
-            xs.all { it in minX..maxX } && ys.all { it in minY..maxY }
-        }
-
-        if (!trianglesInBounds) return false
-
-        val filledArcsInBounds = geometry.filledArcs.all { arc ->
-            arc.bounds(includeCenter = true).isWithin(minX, maxX, minY, maxY)
-        }
-
-        if (!filledArcsInBounds) return false
-
-        val arcsInBounds = geometry.arcs.all { arc ->
-            arc.bounds(includeStroke = true).isWithin(minX, maxX, minY, maxY)
-        }
-
-        if (!arcsInBounds) return false
-
-        val linesInBounds = geometry.lines.all { line ->
-            listOf(line.a, line.b).all { point ->
-                point.x in minX..maxX && point.y in minY..maxY
+        return geometry.elements.all { element ->
+            when (element) {
+                is Polygon -> element.vertices.all { point -> point.x in minX..maxX && point.y in minY..maxY }
+                is Arc -> {
+                    val bounds = if (element.lineWidth <= 0f) element.bounds(includeCenter = true) else element.bounds(includeStroke = true)
+                    bounds.isWithin(minX, maxX, minY, maxY)
+                }
+                is Line -> listOf(element.a, element.b).all { point -> point.x in minX..maxX && point.y in minY..maxY }
+                else -> true
             }
-        }
-        if (!linesInBounds) return false
-
-        return geometry.polygons.all { polygon ->
-            polygon.vertices.all { point -> point.x in minX..maxX && point.y in minY..maxY }
         }
     }
 

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
@@ -161,7 +161,7 @@ class NucleotideRendererTest {
                     bounds.isWithin(minX, maxX, minY, maxY)
                 }
                 is Line -> listOf(element.a, element.b).all { point -> point.x in minX..maxX && point.y in minY..maxY }
-                else -> true
+                else -> error("Unhandled geometry element type in nucleotide bounds test: ${element::class.qualifiedName}")
             }
         }
     }

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/ArcBoundsTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/ArcBoundsTest.kt
@@ -1,5 +1,7 @@
 package life.sim.simulator.rendering.geometry
 
+import com.badlogic.gdx.graphics.Color
+
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -12,6 +14,7 @@ class ArcBoundsTest {
             radius = 10f,
             startDegrees = 0f,
             degrees = 180f,
+            color = Color.WHITE,
             lineWidth = 3f,
         ).bounds()
 
@@ -29,6 +32,7 @@ class ArcBoundsTest {
             radius = 10f,
             startDegrees = 0f,
             degrees = 180f,
+            color = Color.WHITE,
             lineWidth = 4f,
         ).bounds(includeStroke = true)
 
@@ -46,6 +50,7 @@ class ArcBoundsTest {
             radius = 10f,
             startDegrees = 90f,
             degrees = 90f,
+            color = Color.WHITE,
             lineWidth = 3f,
         ).bounds()
 
@@ -55,4 +60,3 @@ class ArcBoundsTest {
         assertEquals(10f, bounds.maxY, 0.0001f)
     }
 }
-

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/GeometryElementOrderTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/GeometryElementOrderTest.kt
@@ -1,0 +1,18 @@
+package life.sim.simulator.rendering.geometry
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.Vector2
+import kotlin.test.*
+
+class GeometryElementOrderTest {
+    @Test
+    fun `constructor preserves provided element order`() {
+        val first = Polygon.rect(0f, 0f, 1f, 1f, color = Color.RED)
+        val second = Arc(1f, 1f, 1f, 0f, 180f, color = Color.BLUE)
+        val third = Line(Vector2(0f, 0f), Vector2(1f, 1f), 1f, Color.GREEN)
+
+        val geometry = Geometry(first, second, third)
+
+        assertEquals(listOf(first, second, third), geometry.elements)
+    }
+}

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonFactoryTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/geometry/PolygonFactoryTest.kt
@@ -1,5 +1,7 @@
 package life.sim.simulator.rendering.geometry
 
+import com.badlogic.gdx.graphics.Color
+
 import com.badlogic.gdx.math.Vector2
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,7 +11,7 @@ import kotlin.test.assertTrue
 class PolygonFactoryTest {
     @Test
     fun `rect creates a closed four-corner polygon`() {
-        val polygon = Polygon.rect(10f, 20f, 30f, 40f)
+        val polygon = Polygon.rect(10f, 20f, 30f, 40f, color = Color.WHITE)
 
         assertEquals(Vector2(10f, 20f), polygon.vertices.first())
         assertEquals(Vector2(10f, 20f), polygon.vertices.last())
@@ -18,7 +20,7 @@ class PolygonFactoryTest {
 
     @Test
     fun `triangle creates a closed triangle polygon`() {
-        val polygon = Polygon.triangle(Vector2(0f, 0f), Vector2(10f, 0f), Vector2(5f, 8f))
+        val polygon = Polygon.triangle(Vector2(0f, 0f), Vector2(10f, 0f), Vector2(5f, 8f), color = Color.WHITE)
 
         assertEquals(4, polygon.vertices.size)
         assertEquals(polygon.vertices.first(), polygon.vertices.last())
@@ -27,7 +29,7 @@ class PolygonFactoryTest {
     @Test
     fun `circle creates closed approximation with requested segments around provided center`() {
         val center = Vector2(3f, -4f)
-        val polygon = Polygon.circle(center, radius = 5f, segments = 12)
+        val polygon = Polygon.circle(center, radius = 5f, color = Color.WHITE, segments = 12)
 
         assertEquals(13, polygon.vertices.size)
         assertEquals(polygon.vertices.first(), polygon.vertices.last())
@@ -37,7 +39,7 @@ class PolygonFactoryTest {
     @Test
     fun `circle rejects non-positive radius`() {
         assertFailsWith<IllegalArgumentException> {
-            Polygon.circle(Vector2(0f, 0f), radius = 0f, segments = 12)
+            Polygon.circle(Vector2(0f, 0f), radius = 0f, color = Color.WHITE, segments = 12)
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make geometry self-contained and preserve explicit render order by introducing renderable elements that own their color/style instead of passing a global color into `Geometry.render(...)`.
- Let common filled shapes be represented as `Polygon` instances with ergonomic factory helpers so callers can compose ordered geometry more easily.

### Description
- Added `GeometryElement` with `fun render(context: RenderContext)` and refactored `Geometry` to hold an ordered `elements: List<GeometryElement>` with a vararg constructor for ergonomic creation.
- Made `Polygon` implement `GeometryElement`, moved `Color` and `PolygonDrawMode` into `Polygon`, and updated `Polygon.of(...)`, `Polygon.rect(...)`, `Polygon.triangle(...)`, and `Polygon.circle(...)` to accept/store `color` and return builders that produce closed `Polygon`s.
- Converted `Arc` and `Line` into `GeometryElement`s that own their `Color`, made `Arc` render filled vs stroked based on `lineWidth`, and updated polygon/arc/line builders/usages accordingly.
- Updated `NucleotideRenderer` to construct an ordered list of `GeometryElement`s (rects, triangles, polygons, arcs) and to call `Geometry.render(context)` without a global color parameter.
- Updated tests and factories to the new API (`Polygon` color param, `Arc` color, and checking `geometry.elements` where appropriate).

### Testing
- Ran targeted unit tests: `./gradlew :simulator:test --tests "life.sim.simulator.rendering.NucleotideRendererTest" --tests "life.sim.simulator.rendering.geometry.PolygonFactoryTest" --tests "life.sim.simulator.rendering.geometry.ArcBoundsTest"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f366a9266483298d70d69dd1d82090)