### PR TITLE
chore(build): configure Java and Kotlin toolchains for version 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,8 @@
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -12,6 +16,24 @@ allprojects {
 }
 
 subprojects {
+    plugins.withId("java") {
+        extensions.configure<JavaPluginExtension> {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(21))
+            }
+        }
+
+        tasks.withType<JavaCompile>().configureEach {
+            options.release.set(21)
+        }
+    }
+
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        extensions.configure<KotlinJvmProjectExtension> {
+            jvmToolchain(21)
+        }
+    }
+
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = "life-sim"
 
 include("biology")


### PR DESCRIPTION
This pull request adds a plugin configuration to the Gradle settings for the project. The main change is the inclusion of the `org.gradle.toolchains.foojay-resolver-convention` plugin, which helps manage Java toolchains more easily.

Build configuration:

* Added the `org.gradle.toolchains.foojay-resolver-convention` plugin (version 0.9.0) to `settings.gradle.kts` to improve Java toolchain resolution and management.