### PR TITLE
Switch simulator rendering to Matrix3 transforms

### DIFF
--- a/simulator/src/main/kotlin/life/sim/simulator/SimWrapper.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/SimWrapper.kt
@@ -1,6 +1,7 @@
 package life.sim.simulator
 
 import com.badlogic.gdx.Input
+import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import life.sim.simulator.rendering.RenderContext
 import life.sim.simulator.rendering.Renderer
@@ -20,8 +21,13 @@ class SimWrapper(
     val position: Vector2,
     var rotation: Float = 0f,
 ) : SimObject, Renderable, Updateable {
+    private val transform = Matrix3()
     private val renderer: Renderer<Any> = requireNotNull(Renderers.forValue(content)) {
         "No renderer registered for type ${content::class.qualifiedName}."
+    }
+
+    init {
+        updateTransform()
     }
 
     override fun update(deltaSeconds: Float, input: Input) {
@@ -30,9 +36,14 @@ class SimWrapper(
         } else if (input.isKeyJustPressed(Input.Keys.R)) {
             rotation = 0f
         }
+        updateTransform()
+    }
+
+    private fun updateTransform() {
+        transform.idt().translate(position.x, position.y).rotate(rotation)
     }
 
     override fun render(context: RenderContext) {
-        renderer.render(content, position, rotation, context)
+        renderer.render(content, transform, context)
     }
 }

--- a/simulator/src/main/kotlin/life/sim/simulator/SimWrapper.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/SimWrapper.kt
@@ -10,11 +10,11 @@ import life.sim.simulator.rendering.Renderers
 /**
  * Bridges domain objects to simulator scene lifecycle by resolving a renderer once at construction.
  *
- * `position` is the wrapped object's visual center in world coordinates.
+ * `position` is the wrapped object's renderer-defined local origin in world coordinates.
  *
- * `rotation` is in degrees and is passed directly to the resolved renderer.
- * The simulator follows libGDX angle conventions: `0f` is unrotated and positive values rotate
- * counterclockwise around `position`.
+ * `rotation` is in degrees and contributes to the composed local-to-world `Matrix3` passed to the
+ * resolved renderer. The simulator follows libGDX angle conventions: `0f` is unrotated and
+ * positive values rotate counterclockwise around `position`.
  */
 class SimWrapper(
     val content: Any,

--- a/simulator/src/main/kotlin/life/sim/simulator/SimulatorApplication.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/SimulatorApplication.kt
@@ -55,6 +55,7 @@ class SimulatorApplication : ApplicationAdapter() {
             viewportHeight = Gdx.graphics.height.toFloat(),
             immediateModeRenderer = immediateModeRenderer,
             sprites = Sprites(),
+            debugMode = false,
         )
         currentScene = DemoScene.sample()
         currentScene.init()

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
@@ -44,6 +44,7 @@ class DnaRenderer(
 
         bottomStrandTransform.idt().translate(layout.bottomStrandPosition.x, layout.bottomStrandPosition.y).mul(transform)
         sequenceRenderer.render(value.reverse, bottomStrandTransform, context)
+        context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.BLUE)
     }
 
     internal fun layout(value: Dna, position: Vector2, rotation: Float = 0f): DnaRenderLayout? {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
@@ -13,6 +13,8 @@ class DnaRenderer(
     val strandGap: Float = baseSize * 0.75f,
 ) : Renderer<Dna> {
     private lateinit var sequenceRenderer: Renderer<NucleotideSequence>
+    private val topStrandTransform = Matrix3()
+    private val bottomStrandTransform = Matrix3()
 
     init {
         Renderers.register(Dna::class, this)
@@ -37,18 +39,11 @@ class DnaRenderer(
             )
         }
 
-        sequenceRenderer.render(
-            value.forward,
-            layout.topStrandPosition.cpy().mul(transform),
-            transform.getRotation(),
-            context,
-        )
-        sequenceRenderer.render(
-            value.reverse,
-            layout.bottomStrandPosition.cpy().mul(transform),
-            transform.getRotation(),
-            context,
-        )
+        topStrandTransform.idt().translate(layout.topStrandPosition.x, layout.topStrandPosition.y).mul(transform)
+        sequenceRenderer.render(value.forward, topStrandTransform, context)
+
+        bottomStrandTransform.idt().translate(layout.bottomStrandPosition.x, layout.bottomStrandPosition.y).mul(transform)
+        sequenceRenderer.render(value.reverse, bottomStrandTransform, context)
     }
 
     internal fun layout(value: Dna, position: Vector2, rotation: Float = 0f): DnaRenderLayout? {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
@@ -41,7 +41,9 @@ class DnaRenderer(
 
         bottomStrandTransform.set(transform).translate(layout.bottomStrandPosition)
         sequenceRenderer.render(value.reverse, bottomStrandTransform, context)
-        context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.BLUE)
+
+        if (context.debugMode)
+            context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.BLUE)
     }
 
     internal fun layout(value: Dna, position: Vector2): DnaRenderLayout? {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import life.sim.biology.molecules.Dna
 import life.sim.biology.primitives.NucleotideSequence
-import life.sim.simulator.rendering.geometry.rotatePoint
 
 class DnaRenderer(
     val baseSize: Float = RenderingVisualSpec.NUCLEOTIDE_BASE_SIZE,
@@ -47,7 +46,7 @@ class DnaRenderer(
         context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.BLUE)
     }
 
-    internal fun layout(value: Dna, position: Vector2, rotation: Float = 0f): DnaRenderLayout? {
+    internal fun layout(value: Dna, position: Vector2): DnaRenderLayout? {
         if (value.isEmpty()) {
             return null
         }
@@ -56,9 +55,6 @@ class DnaRenderer(
         val strandBackboneOffset = (2f * baseSize + strandGap) * 0.5f
         val topStrandBasePosition = Vector2(position.x, position.y + strandBackboneOffset)
         val bottomStrandBasePosition = Vector2(position.x, position.y - strandBackboneOffset)
-
-        val rotatedTopStrandPosition = rotatePoint(topStrandBasePosition, pivot, rotation)
-        val rotatedBottomStrandPosition = rotatePoint(bottomStrandBasePosition, pivot, rotation)
 
         val strandWidth = sequenceWidth(value.forward)
         val leftEdgeX = position.x - strandWidth * 0.5f
@@ -70,8 +66,8 @@ class DnaRenderer(
                 val connectorBottom = Vector2(connectorX, bottomStrandBasePosition.y + baseSize)
                 add(
                     ConnectorSegment(
-                        a = rotatePoint(connectorTop, pivot, rotation),
-                        b = rotatePoint(connectorBottom, pivot, rotation),
+                        a = connectorTop,
+                        b = connectorBottom,
                     ),
                 )
                 connectorX += baseSize + tileGap
@@ -80,8 +76,8 @@ class DnaRenderer(
 
         return DnaRenderLayout(
             pivot = pivot,
-            topStrandPosition = rotatedTopStrandPosition,
-            bottomStrandPosition = rotatedBottomStrandPosition,
+            topStrandPosition = topStrandBasePosition,
+            bottomStrandPosition = bottomStrandBasePosition,
             connectorSegments = connectorSegments,
         )
     }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
@@ -1,6 +1,7 @@
 package life.sim.simulator.rendering
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import life.sim.biology.molecules.Dna
 import life.sim.biology.primitives.NucleotideSequence
@@ -22,13 +23,15 @@ class DnaRenderer(
             ?: error("DnaRenderer requires a registered renderer for NucleotideSequences.")
     }
 
-    override fun render(value: Dna, position: Vector2, rotation: Float, context: RenderContext) {
-        val layout = layout(value, position, rotation) ?: return
+    override fun render(value: Dna, transform: Matrix3, context: RenderContext) {
+        val layout = layout(value, Vector2(0f, 0f)) ?: return
 
         layout.connectorSegments.forEach { connector ->
+            val a = connector.a.cpy().mul(transform)
+            val b = connector.b.cpy().mul(transform)
             context.drawLine(
-                a = connector.a,
-                b = connector.b,
+                a = a,
+                b = b,
                 width = baseSize * 0.08f,
                 color = PAIR_CONNECTOR_COLOR,
             )
@@ -36,14 +39,14 @@ class DnaRenderer(
 
         sequenceRenderer.render(
             value.forward,
-            layout.topStrandPosition,
-            rotation,
+            layout.topStrandPosition.cpy().mul(transform),
+            transform.getRotation(),
             context,
         )
         sequenceRenderer.render(
             value.reverse,
-            layout.bottomStrandPosition,
-            rotation,
+            layout.bottomStrandPosition.cpy().mul(transform),
+            transform.getRotation(),
             context,
         )
     }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/DnaRenderer.kt
@@ -28,20 +28,18 @@ class DnaRenderer(
         val layout = layout(value, Vector2(0f, 0f)) ?: return
 
         layout.connectorSegments.forEach { connector ->
-            val a = connector.a.cpy().mul(transform)
-            val b = connector.b.cpy().mul(transform)
             context.drawLine(
-                a = a,
-                b = b,
+                a = connector.a.mul(transform),
+                b = connector.b.mul(transform),
                 width = baseSize * 0.08f,
                 color = PAIR_CONNECTOR_COLOR,
             )
         }
 
-        topStrandTransform.idt().translate(layout.topStrandPosition.x, layout.topStrandPosition.y).mul(transform)
+        topStrandTransform.set(transform).translate(layout.topStrandPosition)
         sequenceRenderer.render(value.forward, topStrandTransform, context)
 
-        bottomStrandTransform.idt().translate(layout.bottomStrandPosition.x, layout.bottomStrandPosition.y).mul(transform)
+        bottomStrandTransform.set(transform).translate(layout.bottomStrandPosition)
         sequenceRenderer.render(value.reverse, bottomStrandTransform, context)
         context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.BLUE)
     }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -2,6 +2,7 @@ package life.sim.simulator.rendering
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.TextureRegion
+import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import life.sim.biology.primitives.Nucleotide
 import life.sim.simulator.rendering.geometry.*
@@ -19,12 +20,12 @@ class NucleotideRenderer(
         // Nothing to do here since this renderer has no dependencies on other renderers.
     }
 
-    override fun render(value: Nucleotide, position: Vector2, rotation: Float, context: RenderContext) {
+    override fun render(value: Nucleotide, transform: Matrix3, context: RenderContext) {
         val key = requireNotNull(spriteKey(value))
         context.sprites.getOrCreate(key) { renderToSpriteCached(value, context) }
-        val anchor = lowerLeftFromCenter(position)
-        context.drawSprite(key, anchor, rotation)
-        context.drawCenteredText(value.symbol.toString(), position.x, position.y)
+        context.drawSprite(key, transform)
+        val labelPosition = Vector2(0f, 0f).mul(transform)
+        context.drawCenteredText(value.symbol.toString(), labelPosition.x, labelPosition.y)
     }
 
     internal fun lowerLeftFromCenter(center: Vector2): Vector2 =

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -28,7 +28,8 @@ class NucleotideRenderer(
         context.drawSprite(key, transform)
         labelPosition.set(baseSize * 0.5f, 0f).mul(transform)
         context.drawCenteredText(value.symbol.toString(), labelPosition.x, labelPosition.y)
-        context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.WHITE)
+        if (context.debugMode)
+            context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.WHITE)
     }
 
     internal fun lowerLeftFromCenter(center: Vector2): Vector2 =

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -6,12 +6,13 @@ import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import life.sim.biology.primitives.Nucleotide
 import life.sim.simulator.rendering.geometry.*
+import kotlin.math.ceil
 
 class NucleotideRenderer(
     val baseSize: Float = RenderingVisualSpec.NUCLEOTIDE_BASE_SIZE,
 ) : Renderer<Nucleotide> {
     private val pairingBandSize = baseSize * 0.5f
-    private val labelPosition = Vector2()
+    private val labelPosition = Vector2(baseSize * 0.5f, baseSize * 0.5f)
 
     init {
         Renderers.register(Nucleotide::class, this)
@@ -25,8 +26,9 @@ class NucleotideRenderer(
         val key = requireNotNull(spriteKey(value))
         context.sprites.getOrCreate(key) { renderToSpriteCached(value, context) }
         context.drawSprite(key, transform)
-        labelPosition.set(0f, 0f).mul(transform)
+        labelPosition.set(baseSize * 0.5f, 0f).mul(transform)
         context.drawCenteredText(value.symbol.toString(), labelPosition.x, labelPosition.y)
+        context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.WHITE)
     }
 
     internal fun lowerLeftFromCenter(center: Vector2): Vector2 =
@@ -39,24 +41,23 @@ class NucleotideRenderer(
 
     private fun renderToSpriteCached(value: Nucleotide, context: RenderContext): CachedSprite {
         val key = spriteKey(value)
-        val spriteSize = kotlin.math.ceil(baseSize + 2f * pairingBandSize).toInt()
-        val origin = pairingBandSize + baseSize * 0.5f
+        val origin = Vector2(0f, baseSize * 0.5f)
+        val spriteSize = Vector2(ceil(baseSize * 1.5f), ceil(baseSize))
         context.finish()
         return context.sprites.renderToSprite(
             key,
-            spriteSize,
-            spriteSize,
-            originX = origin,
-            originY = origin,
+            spriteSize.x.toInt(),
+            spriteSize.y.toInt(),
+            originX = origin.x,
+            originY = origin.y,
         ) {
             val previousProjection = context.shapeRenderer.projectionMatrix.cpy()
             val previousBatchProjection = context.batch.projectionMatrix.cpy()
             try {
-                context.shapeRenderer.projectionMatrix.setToOrtho2D(0f, 0f, spriteSize.toFloat(), spriteSize.toFloat())
-                context.batch.projectionMatrix.setToOrtho2D(0f, 0f, spriteSize.toFloat(), spriteSize.toFloat())
+                context.shapeRenderer.projectionMatrix.setToOrtho2D(0f, 0f, spriteSize.x, spriteSize.y)
+                context.batch.projectionMatrix.setToOrtho2D(0f, 0f, spriteSize.x, spriteSize.y)
                 try {
-                    val lowerLeft = origin - baseSize * 0.5f
-                    renderUncached(value, Vector2(lowerLeft, lowerLeft), context, NucleotideOrientation(PairingSide.RIGHT))
+                    renderUncached(value, Vector2(0f, 0f), context)
                 } finally {
                     context.finish()
                 }
@@ -71,9 +72,8 @@ class NucleotideRenderer(
         value: Nucleotide,
         position: Vector2,
         context: RenderContext,
-        orientation: NucleotideOrientation,
     ) {
-        geometryFor(value, position, orientation, nucleotideColor(value)).render(context)
+        geometryFor(value, position, nucleotideColor(value)).render(context)
     }
 
     internal fun connectorProfile(nucleotide: Nucleotide): ConnectorProfile = when (nucleotide) {
@@ -93,7 +93,6 @@ class NucleotideRenderer(
     internal fun geometryFor(
         nucleotide: Nucleotide,
         position: Vector2,
-        orientation: NucleotideOrientation,
         color: Color = nucleotideColor(nucleotide),
     ): Geometry {
         val profile = connectorProfile(nucleotide)
@@ -103,19 +102,19 @@ class NucleotideRenderer(
             ConnectorFamily.ANGLED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
                     elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color.cpy())
-                    elements += triangleOnSide(position, orientation.pairingSide, color.cpy())
+                    elements += triangleOnSide(position, color.cpy())
                 } else {
                     elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color.cpy())
-                    elements += inverseTriangleOnSide(position, orientation.pairingSide, color.cpy())
+                    elements += inverseTriangleOnSide(position, color.cpy())
                 }
             }
 
             ConnectorFamily.ROUNDED -> {
                 if (profile.polarity == ConnectorPolarity.PROTRUSION) {
                     elements += Polygon.rect(position.x, position.y, baseSize, baseSize, color = color.cpy())
-                    elements += roundedProtrusionPolygonOnSide(position, orientation.pairingSide, color.cpy())
+                    elements += roundedProtrusionPolygonOnSide(position, color.cpy())
                 } else {
-                    elements += roundedSocketPolygonOnSide(position, orientation.pairingSide, color.cpy())
+                    elements += roundedSocketPolygonOnSide(position, color.cpy())
                 }
             }
         }
@@ -123,56 +122,10 @@ class NucleotideRenderer(
         return Geometry(elements)
     }
 
-    private fun inverseTriangleOnSide(position: Vector2, side: PairingSide, color: Color): List<Polygon> {
+    private fun inverseTriangleOnSide(position: Vector2, color: Color): List<Polygon> {
         val x = position.x
         val y = position.y
-        return when (side) {
-            PairingSide.TOP -> listOf(
-                Polygon.triangle(
-                    Vector2(x, y + baseSize),
-                    Vector2(x, y + baseSize + pairingBandSize),
-                    Vector2(x + baseSize * 0.5f, y + baseSize),
-                    color = color
-                ),
-                Polygon.triangle(
-                    Vector2(x + baseSize * 0.5f, y + baseSize),
-                    Vector2(x + baseSize, y + baseSize + pairingBandSize),
-                    Vector2(x + baseSize, y + baseSize),
-                    color = color
-                ),
-            )
-
-            PairingSide.BOTTOM -> listOf(
-                Polygon.triangle(
-                    Vector2(x, y),
-                    Vector2(x + baseSize * 0.5f, y),
-                    Vector2(x, y - pairingBandSize),
-                    color = color
-                ),
-                Polygon.triangle(
-                    Vector2(x + baseSize * 0.5f, y),
-                    Vector2(x + baseSize, y),
-                    Vector2(x + baseSize, y - pairingBandSize),
-                    color = color
-                ),
-            )
-
-            PairingSide.LEFT -> listOf(
-                Polygon.triangle(
-                    Vector2(x, y + baseSize),
-                    Vector2(x, y + baseSize * 0.5f),
-                    Vector2(x - pairingBandSize, y + baseSize),
-                    color = color
-                ),
-                Polygon.triangle(
-                    Vector2(x, y + baseSize * 0.5f),
-                    Vector2(x, y),
-                    Vector2(x - pairingBandSize, y),
-                    color = color
-                ),
-            )
-
-            PairingSide.RIGHT -> listOf(
+        return listOf(
                 Polygon.triangle(
                     Vector2(x + baseSize, y + baseSize),
                     Vector2(x + baseSize + pairingBandSize, y + baseSize),
@@ -186,143 +139,42 @@ class NucleotideRenderer(
                     color = color
                 ),
             )
-        }
     }
 
-    private fun triangleOnSide(position: Vector2, side: PairingSide, color: Color): Polygon {
+    private fun triangleOnSide(position: Vector2, color: Color): Polygon {
         val x = position.x
         val y = position.y
-        return when (side) {
-            PairingSide.LEFT -> Polygon.triangle(
-                Vector2(x, y),
-                Vector2(x, y + baseSize),
-                Vector2(x - pairingBandSize, y + baseSize * 0.5f),
-                color = color
-            )
-
-            PairingSide.RIGHT -> Polygon.triangle(
+        return Polygon.triangle(
                 Vector2(x + baseSize, y),
                 Vector2(x + baseSize + pairingBandSize, y + baseSize * 0.5f),
                 Vector2(x + baseSize, y + baseSize),
                 color = color
             )
-
-            PairingSide.TOP -> Polygon.triangle(
-                Vector2(x, y + baseSize),
-                Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize),
-                Vector2(x + baseSize, y + baseSize),
-                color = color
-            )
-
-            PairingSide.BOTTOM -> Polygon.triangle(
-                Vector2(x, y),
-                Vector2(x + baseSize, y),
-                Vector2(x + baseSize * 0.5f, y - pairingBandSize),
-                color = color
-            )
-        }
     }
 
-    private fun roundedProtrusionPolygonOnSide(position: Vector2, side: PairingSide, color: Color): Polygon {
-        val x = position.x
-        val y = position.y
-        return when (side) {
-            PairingSide.LEFT -> Polygon.of(
-                Vector2(x + baseSize, y),
-                Vector2(x + baseSize, y + baseSize),
-                Vector2(x, y + baseSize),
+    private fun roundedProtrusionPolygonOnSide(position: Vector2, color: Color): Polygon {
+        return Polygon.of(
+                position,
+                Vector2(position.x + baseSize, position.y),
+                Vector2(position.x + baseSize, position.y + baseSize),
                 color = color,
             )
                 .add(
                     arc(
-                        start = Vector2(x, y + baseSize),
-                        center = Vector2(x, y + baseSize * 0.5f),
-                        end = Vector2(x, y),
-                        segments = 10,
-                        sweepDirection = ArcSweepDirection.COUNTERCLOCKWISE,
-                    ),
-                )
-                .close()
-
-            PairingSide.RIGHT -> Polygon.of(
-                Vector2(x, y),
-                Vector2(x + baseSize, y),
-                Vector2(x + baseSize, y + baseSize),
-                color = color,
-            )
-                .add(
-                    arc(
-                        start = Vector2(x + baseSize, y + baseSize),
-                        center = Vector2(x + baseSize, y + baseSize * 0.5f),
-                        end = Vector2(x + baseSize, y),
+                        start = Vector2(position.x + baseSize, position.y + baseSize),
+                        center = Vector2(position.x + baseSize, position.y + baseSize * 0.5f),
+                        end = Vector2(position.x + baseSize, position.y),
                         segments = 10,
                         sweepDirection = ArcSweepDirection.CLOCKWISE,
                     ),
                 )
                 .close()
-
-            PairingSide.TOP -> Polygon.of(
-                Vector2(x, y),
-                Vector2(x + baseSize, y),
-                Vector2(x + baseSize, y + baseSize),
-                color = color,
-            )
-                .add(
-                    arc(
-                        start = Vector2(x + baseSize, y + baseSize),
-                        center = Vector2(x + baseSize * 0.5f, y + baseSize),
-                        end = Vector2(x, y + baseSize),
-                        segments = 10,
-                        sweepDirection = ArcSweepDirection.COUNTERCLOCKWISE,
-                    ),
-                )
-                .close()
-
-            PairingSide.BOTTOM -> Polygon.of(
-                Vector2(x + baseSize, y + baseSize),
-                Vector2(x, y + baseSize),
-                Vector2(x, y),
-                color = color,
-            )
-                .add(
-                    arc(
-                        start = Vector2(x, y),
-                        center = Vector2(x + baseSize * 0.5f, y),
-                        end = Vector2(x + baseSize, y),
-                        segments = 10,
-                        sweepDirection = ArcSweepDirection.COUNTERCLOCKWISE,
-                    ),
-                )
-                .close()
-        }
     }
 
-    private fun roundedSocketPolygonOnSide(position: Vector2, side: PairingSide, color: Color): Polygon {
+    private fun roundedSocketPolygonOnSide(position: Vector2, color: Color): Polygon {
         val x = position.x
         val y = position.y
-        return when (side) {
-            PairingSide.LEFT -> Polygon.of(
-                Vector2(x + baseSize, y + baseSize),
-                Vector2(x, y + baseSize),
-                Vector2(x - pairingBandSize, y + baseSize),
-                color = color,
-            )
-                .add(
-                    arc(
-                        start = Vector2(x - pairingBandSize, y + baseSize),
-                        center = Vector2(x - pairingBandSize, y + baseSize * 0.5f),
-                        end = Vector2(x - pairingBandSize, y),
-                        segments = 10,
-                        sweepDirection = ArcSweepDirection.CLOCKWISE,
-                    ),
-                )
-                .add(
-                    Vector2(x, y),
-                    Vector2(x + baseSize, y),
-                )
-                .close()
-
-            PairingSide.RIGHT -> Polygon.of(
+        return Polygon.of(
                 Vector2(x, y + baseSize),
                 Vector2(x + baseSize, y + baseSize),
                 Vector2(x + baseSize + pairingBandSize, y + baseSize),
@@ -342,46 +194,6 @@ class NucleotideRenderer(
                     Vector2(x, y),
                 )
                 .close()
-
-            PairingSide.TOP -> Polygon.of(
-                Vector2(x, y),
-                Vector2(x + baseSize, y),
-                Vector2(x + baseSize, y + baseSize),
-                Vector2(x + baseSize, y + baseSize + pairingBandSize),
-                color = color,
-            )
-                .add(
-                    arc(
-                        start =Vector2(x + baseSize, y + baseSize + pairingBandSize),
-                        center = Vector2(x + baseSize * 0.5f, y + baseSize + pairingBandSize),
-                        end = Vector2(x, y + baseSize + pairingBandSize),
-                        segments = 10,
-                        sweepDirection = ArcSweepDirection.CLOCKWISE,
-                    ),
-                )
-                .add(Vector2(x, y + baseSize))
-                .close()
-
-            PairingSide.BOTTOM -> Polygon
-                .of(
-                    Vector2(x + baseSize, y + baseSize),
-                    Vector2(x, y + baseSize),
-                    Vector2(x, y),
-                    Vector2(x, y - pairingBandSize),
-                    color = color
-                )
-                .add(
-                    arc(
-                        start = Vector2(x, y - pairingBandSize),
-                        center = Vector2(x + baseSize * 0.5f, y - pairingBandSize),
-                        end = Vector2(x + baseSize, y - pairingBandSize),
-                        segments = 10,
-                        sweepDirection = ArcSweepDirection.CLOCKWISE,
-                    )
-                )
-                .add(Vector2(x + baseSize, y))
-                .close()
-        }
     }
 
     companion object {
@@ -411,15 +223,4 @@ internal enum class ConnectorFamily {
 internal enum class ConnectorPolarity {
     PROTRUSION,
     INDENTATION,
-}
-
-data class NucleotideOrientation(
-    val pairingSide: PairingSide = PairingSide.RIGHT,
-)
-
-enum class PairingSide {
-    LEFT,
-    RIGHT,
-    TOP,
-    BOTTOM,
 }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -11,6 +11,7 @@ class NucleotideRenderer(
     val baseSize: Float = RenderingVisualSpec.NUCLEOTIDE_BASE_SIZE,
 ) : Renderer<Nucleotide> {
     private val pairingBandSize = baseSize * 0.5f
+    private val labelPosition = Vector2()
 
     init {
         Renderers.register(Nucleotide::class, this)
@@ -24,7 +25,7 @@ class NucleotideRenderer(
         val key = requireNotNull(spriteKey(value))
         context.sprites.getOrCreate(key) { renderToSpriteCached(value, context) }
         context.drawSprite(key, transform)
-        val labelPosition = Vector2(0f, 0f).mul(transform)
+        labelPosition.set(0f, 0f).mul(transform)
         context.drawCenteredText(value.symbol.toString(), labelPosition.x, labelPosition.y)
     }
 

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideRenderer.kt
@@ -40,17 +40,14 @@ class NucleotideRenderer(
     private fun renderToSpriteCached(value: Nucleotide, context: RenderContext): CachedSprite {
         val key = spriteKey(value)
         val spriteSize = kotlin.math.ceil(baseSize + 2f * pairingBandSize).toInt()
-        val tileOrigin = pairingBandSize
-        val rotationOrigin = pairingBandSize + baseSize * 0.5f
+        val origin = pairingBandSize + baseSize * 0.5f
         context.finish()
         return context.sprites.renderToSprite(
             key,
             spriteSize,
             spriteSize,
-            tileOriginX = tileOrigin,
-            tileOriginY = tileOrigin,
-            rotationOriginX = rotationOrigin,
-            rotationOriginY = rotationOrigin,
+            originX = origin,
+            originY = origin,
         ) {
             val previousProjection = context.shapeRenderer.projectionMatrix.cpy()
             val previousBatchProjection = context.batch.projectionMatrix.cpy()
@@ -58,7 +55,8 @@ class NucleotideRenderer(
                 context.shapeRenderer.projectionMatrix.setToOrtho2D(0f, 0f, spriteSize.toFloat(), spriteSize.toFloat())
                 context.batch.projectionMatrix.setToOrtho2D(0f, 0f, spriteSize.toFloat(), spriteSize.toFloat())
                 try {
-                    renderUncached(value, Vector2(tileOrigin, tileOrigin), context, NucleotideOrientation(PairingSide.RIGHT))
+                    val lowerLeft = origin - baseSize * 0.5f
+                    renderUncached(value, Vector2(lowerLeft, lowerLeft), context, NucleotideOrientation(PairingSide.RIGHT))
                 } finally {
                     context.finish()
                 }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
@@ -52,9 +52,8 @@ class NucleotideSequenceRenderer(
 
         val nucleotideAnchors = buildList(value.size) {
             var x = leftEdgeX + baseSize * 0.5f
-            val nucleotideCenterY = nucleotideCenterY(position.y, value.direction)
             repeat(value.size) {
-                add(Vector2(x, nucleotideCenterY))
+                add(Vector2(x, position.y))
                 x += baseSize + tileGap
             }
         }
@@ -74,17 +73,17 @@ class NucleotideSequenceRenderer(
         transform: Matrix3,
         context: RenderContext,
     ) {
-        context.drawLine(
-            layout.backboneStart,
-            layout.backboneEnd,
-            width = BACKBONE_WIDTH,
-            color = BACKBONE_COLOR,
-        )
-
         value.zip(layout.nucleotideAnchors).forEach { (nucleotide, anchor) ->
             nucleotidePosition.set(anchor).mul(transform)
             nucleotideRenderer.render(nucleotide, nucleotidePosition, nucleotideRotation(value.direction, transform.getRotation()), context)
         }
+
+        context.drawLine(
+            layout.backboneStart.mul(transform),
+            layout.backboneEnd.mul(transform),
+            width = BACKBONE_WIDTH,
+            color = BACKBONE_COLOR,
+        )
 
         val directionIndicatorVertices = layout.directionIndicatorVertices.map { it.cpy().mul(transform) }
         context.drawFilledTriangle(

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
@@ -14,7 +14,7 @@ class NucleotideSequenceRenderer(
     val baseSize: Float = RenderingVisualSpec.NUCLEOTIDE_BASE_SIZE,
 ) : Renderer<NucleotideSequence> {
     private lateinit var nucleotideRenderer: Renderer<Nucleotide>
-    private val nucleotidePosition = Vector2()
+    private val nucleotideTransform = Matrix3()
 
     init {
         Renderers.register(NucleotideSequence::class, this)
@@ -75,8 +75,8 @@ class NucleotideSequenceRenderer(
         context: RenderContext,
     ) {
         value.zip(layout.nucleotideAnchors).forEach { (nucleotide, anchor) ->
-            nucleotidePosition.set(anchor).mul(transform)
-            nucleotideRenderer.render(nucleotide, nucleotidePosition, nucleotideRotation(value.direction, transform.getRotation()), context)
+            nucleotideTransform.set(transform).translate(anchor).rotate(nucleotideRotation(value.direction))
+            nucleotideRenderer.render(nucleotide, nucleotideTransform, context)
         }
 
         context.drawLine(
@@ -132,13 +132,12 @@ class NucleotideSequenceRenderer(
             backboneY + baseSize * 0.5f
         }
 
-    internal fun nucleotideRotation(direction: SequenceDirection, modelRotation: Float): Float {
-        val strandFacingOffset = if (direction == SequenceDirection.FORWARD) {
+    internal fun nucleotideRotation(direction: SequenceDirection): Float {
+        return if (direction == SequenceDirection.FORWARD) {
             FORWARD_STRAND_FACING_OFFSET
         } else {
             BACKWARD_STRAND_FACING_OFFSET
         }
-        return modelRotation + strandFacingOffset
     }
 
     companion object {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
@@ -28,6 +28,7 @@ class NucleotideSequenceRenderer(
     override fun render(value: NucleotideSequence, transform: Matrix3, context: RenderContext) {
         val layout = layout(value, Vector2(0f, 0f)) ?: return
         renderLayout(value, layout, transform, context)
+        context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.GREEN)
     }
 
     fun sequenceWidth(value: NucleotideSequence): Float {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
@@ -28,7 +28,8 @@ class NucleotideSequenceRenderer(
     override fun render(value: NucleotideSequence, transform: Matrix3, context: RenderContext) {
         val layout = layout(value, Vector2(0f, 0f)) ?: return
         renderLayout(value, layout, transform, context)
-        context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.GREEN)
+        if (context.debugMode)
+            context.drawCircle(transform.getTranslation(Vector2()), baseSize * 0.1f, Color.GREEN)
     }
 
     fun sequenceWidth(value: NucleotideSequence): Float {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/NucleotideSequenceRenderer.kt
@@ -1,6 +1,7 @@
 package life.sim.simulator.rendering
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import life.sim.biology.primitives.Nucleotide
 import life.sim.biology.primitives.NucleotideSequence
@@ -24,9 +25,9 @@ class NucleotideSequenceRenderer(
             ?: error("NucleotideSequenceRenderer requires a registered renderer for Nucleotide.")
     }
 
-    override fun render(value: NucleotideSequence, position: Vector2, rotation: Float, context: RenderContext) {
-        val layout = layout(value, position)?.rotated(rotation) ?: return
-        renderLayout(value, layout, rotation, context)
+    override fun render(value: NucleotideSequence, transform: Matrix3, context: RenderContext) {
+        val layout = layout(value, Vector2(0f, 0f)) ?: return
+        renderLayout(value, layout, transform, context)
     }
 
     fun sequenceWidth(value: NucleotideSequence): Float {
@@ -69,7 +70,7 @@ class NucleotideSequenceRenderer(
     internal fun renderLayout(
         value: NucleotideSequence,
         layout: SequenceRenderLayout,
-        rotation: Float,
+        transform: Matrix3,
         context: RenderContext,
     ) {
         context.drawLine(
@@ -80,16 +81,11 @@ class NucleotideSequenceRenderer(
         )
 
         value.zip(layout.nucleotideAnchors).forEach { (nucleotide, anchor) ->
-            nucleotidePosition.set(anchor)
-            nucleotideRenderer.render(
-                nucleotide,
-                nucleotidePosition,
-                nucleotideRotation(value.direction, rotation),
-                context,
-            )
+            nucleotidePosition.set(anchor).mul(transform)
+            nucleotideRenderer.render(nucleotide, nucleotidePosition, nucleotideRotation(value.direction, transform.getRotation()), context)
         }
 
-        val directionIndicatorVertices = layout.directionIndicatorVertices
+        val directionIndicatorVertices = layout.directionIndicatorVertices.map { it.cpy().mul(transform) }
         context.drawFilledTriangle(
             directionIndicatorVertices[0].x,
             directionIndicatorVertices[0].y,

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
@@ -38,6 +38,7 @@ data class RenderContext(
     var viewportHeight: Float,
     val immediateModeRenderer: ImmediateModeRenderer20,
     val sprites: Sprites,
+    val debugMode: Boolean,
 ) {
     private enum class DrawMode {
         NONE,

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
@@ -9,6 +9,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion
 import com.badlogic.gdx.graphics.glutils.ImmediateModeRenderer20
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType
+import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.MathUtils
 import com.badlogic.gdx.math.Vector2
 import life.sim.simulator.rendering.geometry.*
@@ -16,8 +17,13 @@ import kotlin.math.cbrt
 import kotlin.math.max
 
 interface Renderer<T : Any> {
-    fun render(value: T, position: Vector2, rotation: Float, context: RenderContext)
+    fun render(value: T, transform: Matrix3, context: RenderContext)
     fun init()
+
+    fun render(value: T, position: Vector2, rotation: Float, context: RenderContext) {
+        val transform = Matrix3().idt().translate(position.x, position.y).rotate(rotation)
+        render(value, transform, context)
+    }
 
     fun spriteKey(value: T): SpriteKey? = null
 
@@ -175,11 +181,10 @@ data class RenderContext(
 
     fun drawSprite(
         key: SpriteKey,
-        position: Vector2,
-        rotationDegrees: Float = 0f,
+        transform: Matrix3,
     ) {
         ensureBatchMode()
-        sprites.draw(key, batch, position, rotationDegrees)
+        sprites.draw(key, batch, transform)
     }
 
     fun finish() {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
@@ -21,7 +21,7 @@ interface Renderer<T : Any> {
     fun init()
 
     fun render(value: T, position: Vector2, rotation: Float, context: RenderContext) {
-        val transform = Matrix3().idt().translate(position.x, position.y).rotate(rotation)
+        val transform = Matrix3().idt().translate(position).rotate(rotation)
         render(value, transform, context)
     }
 

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderer.kt
@@ -224,4 +224,10 @@ data class RenderContext(
         batch.begin()
         mode = DrawMode.BATCH
     }
+
+    fun drawCircle(translation: Vector2, radius: Float, color: Color) {
+        ensureShapeMode()
+        shapeRenderer.color = color
+        shapeRenderer.circle(translation.x, translation.y, radius)
+    }
 }

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderers.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Renderers.kt
@@ -1,5 +1,6 @@
 package life.sim.simulator.rendering
 
+import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import kotlin.reflect.KClass
 
@@ -20,10 +21,10 @@ object Renderers {
     fun forValue(value: Any): Renderer<Any>? =
         renderers[value::class] as? Renderer<Any>
 
-    fun render(value: Any, position: Vector2, rotation: Float, context: RenderContext) {
+    fun render(value: Any, transform: Matrix3, context: RenderContext) {
         requireNotNull(forValue(value)) {
             "No renderer registered for type ${value::class.qualifiedName}."
-        }.render(value, position, rotation, context)
+        }.render(value, transform, context)
     }
 
     fun init() {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Sprites.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Sprites.kt
@@ -7,7 +7,8 @@ import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.g2d.TextureRegion
 import com.badlogic.gdx.graphics.glutils.FrameBuffer
-import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.math.Affine2
+import com.badlogic.gdx.math.Matrix3
 
 data class CachedSprite(
     val region: TextureRegion,
@@ -26,27 +27,10 @@ class Sprites {
     fun getOrCreate(key: SpriteKey, generator: () -> CachedSprite): CachedSprite =
         sprites.getOrPut(key, generator)
 
-    fun draw(
-        key: SpriteKey,
-        batch: SpriteBatch,
-        position: Vector2,
-        rotationDegrees: Float = 0f,
-    ) {
+    fun draw(key: SpriteKey, batch: SpriteBatch, transform: Matrix3) {
         val sprite = requireNotNull(sprites[key]) { "Sprite not found for key: $key" }
-        val x = position.x - sprite.tileOriginX
-        val y = position.y - sprite.tileOriginY
-        batch.draw(
-            sprite.region,
-            x,
-            y,
-            sprite.rotationOriginX,
-            sprite.rotationOriginY,
-            sprite.width,
-            sprite.height,
-            1f,
-            1f,
-            rotationDegrees,
-        )
+        val affine = Affine2().set(transform).translate(-sprite.tileOriginX, -sprite.tileOriginY)
+        batch.draw(sprite.region, sprite.width, sprite.height, affine)
     }
 
     fun putPixmap(key: SpriteKey, pixmap: Pixmap): CachedSprite {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Sprites.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Sprites.kt
@@ -21,14 +21,14 @@ data class CachedSprite(
 class Sprites {
     private val sprites = mutableMapOf<SpriteKey, CachedSprite>()
     private val ownedTextures = mutableSetOf<Texture>()
+    private val affine = Affine2()
 
     fun getOrCreate(key: SpriteKey, generator: () -> CachedSprite): CachedSprite =
         sprites.getOrPut(key, generator)
 
     fun draw(key: SpriteKey, batch: SpriteBatch, transform: Matrix3) {
         val sprite = requireNotNull(sprites[key]) { "Sprite not found for key: $key" }
-        val affine = Affine2().set(transform).translate(-sprite.originX, -sprite.originY)
-        batch.draw(sprite.region, sprite.width, sprite.height, affine)
+        batch.draw(sprite.region, sprite.width, sprite.height, affine.set(transform).translate(-sprite.originX, -sprite.originY))
     }
 
     fun putPixmap(key: SpriteKey, pixmap: Pixmap): CachedSprite {

--- a/simulator/src/main/kotlin/life/sim/simulator/rendering/Sprites.kt
+++ b/simulator/src/main/kotlin/life/sim/simulator/rendering/Sprites.kt
@@ -14,10 +14,8 @@ data class CachedSprite(
     val region: TextureRegion,
     val width: Float,
     val height: Float,
-    val tileOriginX: Float,
-    val tileOriginY: Float,
-    val rotationOriginX: Float,
-    val rotationOriginY: Float,
+    val originX: Float,
+    val originY: Float,
 )
 
 class Sprites {
@@ -29,7 +27,7 @@ class Sprites {
 
     fun draw(key: SpriteKey, batch: SpriteBatch, transform: Matrix3) {
         val sprite = requireNotNull(sprites[key]) { "Sprite not found for key: $key" }
-        val affine = Affine2().set(transform).translate(-sprite.tileOriginX, -sprite.tileOriginY)
+        val affine = Affine2().set(transform).translate(-sprite.originX, -sprite.originY)
         batch.draw(sprite.region, sprite.width, sprite.height, affine)
     }
 
@@ -47,10 +45,8 @@ class Sprites {
                 region,
                 region.regionWidth.toFloat(),
                 region.regionHeight.toFloat(),
-                tileOriginX = 0f,
-                tileOriginY = 0f,
-                rotationOriginX = 0f,
-                rotationOriginY = 0f,
+                originX = 0f,
+                originY = 0f,
                 ownsTexture = true,
             )
         } catch (error: Throwable) {
@@ -64,13 +60,11 @@ class Sprites {
         region: TextureRegion,
         width: Float,
         height: Float,
-        tileOriginX: Float,
-        tileOriginY: Float,
-        rotationOriginX: Float,
-        rotationOriginY: Float,
+        originX: Float,
+        originY: Float,
         ownsTexture: Boolean = false,
     ): CachedSprite {
-        val sprite = CachedSprite(region, width, height, tileOriginX, tileOriginY, rotationOriginX, rotationOriginY)
+        val sprite = CachedSprite(region, width, height, originX, originY)
         val previous = sprites.put(key, sprite)
         if (previous != null) {
             maybeDisposeOwned(previous.region.texture)
@@ -85,10 +79,8 @@ class Sprites {
         key: SpriteKey,
         width: Int,
         height: Int,
-        tileOriginX: Float,
-        tileOriginY: Float,
-        rotationOriginX: Float,
-        rotationOriginY: Float,
+        originX: Float,
+        originY: Float,
         render: () -> Unit,
     ): CachedSprite {
         val safeWidth = width.coerceAtLeast(1)
@@ -121,10 +113,8 @@ class Sprites {
             region,
             safeWidth.toFloat(),
             safeHeight.toFloat(),
-            tileOriginX,
-            tileOriginY,
-            rotationOriginX,
-            rotationOriginY,
+            originX,
+            originY,
             ownsTexture = true,
         )
     }

--- a/simulator/src/test/kotlin/life/sim/simulator/SimWrapperTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/SimWrapperTest.kt
@@ -1,6 +1,7 @@
 package life.sim.simulator
 
 import com.badlogic.gdx.Input
+import com.badlogic.gdx.math.Matrix3
 import com.badlogic.gdx.math.Vector2
 import life.sim.simulator.rendering.RenderContext
 import life.sim.simulator.rendering.Renderer
@@ -69,6 +70,20 @@ class SimWrapperTest {
         assertEquals(100f, wrapper.rotation)
     }
 
+
+    @Test
+    fun `Matrix3 local to world transform keeps translation then rotation order`() {
+        val transform = Matrix3().idt().translate(10f, 20f).rotate(90f)
+
+        val origin = Vector2(0f, 0f).mul(transform)
+        val right = Vector2(1f, 0f).mul(transform)
+
+        assertEquals(10f, origin.x, 0.0001f)
+        assertEquals(20f, origin.y, 0.0001f)
+        assertEquals(10f, right.x, 0.0001f)
+        assertEquals(21f, right.y, 0.0001f)
+    }
+
     private fun dummyInput(
         pressedKeys: Set<Int> = emptySet(),
         justPressedKeys: Set<Int> = emptySet(),
@@ -100,7 +115,7 @@ class SimWrapperTest {
     private data object NoRendererType
 
     private object WrappedTypeRenderer : Renderer<WrappedType> {
-        override fun render(value: WrappedType, position: Vector2, rotation: Float, context: RenderContext) = Unit
+        override fun render(value: WrappedType, transform: Matrix3, context: RenderContext) = Unit
         override fun init() = Unit
     }
 }

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
@@ -193,19 +193,16 @@ class NucleotideRendererTest {
     }
 
     @Test
-    fun `renderToSpriteCached uses tile origin padding and center rotation origin`() {
+    fun `renderToSpriteCached uses centered sprite origin`() {
         val renderer = NucleotideRenderer(baseSize = 40f)
         val baseSize = renderer.baseSize
         val pairingBandSize = baseSize * 0.5f
         val spriteSize = baseSize + 2f * pairingBandSize
 
-        val tileOrigin = pairingBandSize
-        val rotationOrigin = pairingBandSize + baseSize * 0.5f
+        val origin = pairingBandSize + baseSize * 0.5f
 
-        assertEquals(pairingBandSize, tileOrigin)
-        assertEquals(pairingBandSize, tileOrigin)
-        assertEquals(baseSize * 0.5f + pairingBandSize, rotationOrigin)
-        assertEquals(baseSize * 0.5f + pairingBandSize, rotationOrigin)
+        assertEquals(baseSize * 0.5f + pairingBandSize, origin)
+        assertEquals(baseSize * 0.5f + pairingBandSize, origin)
         assertEquals(baseSize + 2f * pairingBandSize, spriteSize)
     }
 

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideRendererTest.kt
@@ -44,13 +44,10 @@ class NucleotideRendererTest {
     fun `geometryFor keeps every nucleotide shape inside the geometry test window`() {
         val origin = Vector2(10f, 20f)
         val nucleotides = listOf(Nucleotide.A, Nucleotide.U, Nucleotide.C, Nucleotide.G)
-        val pairingSides = listOf(PairingSide.LEFT, PairingSide.RIGHT, PairingSide.TOP, PairingSide.BOTTOM)
 
         nucleotides.forEach { nucleotide ->
-            pairingSides.forEach { pairingSide ->
-                val geometry = renderer.geometryFor(nucleotide, origin, NucleotideOrientation(pairingSide))
-                assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin), "Expected $nucleotide on $pairingSide to stay inside the geometry test window")
-            }
+            val geometry = renderer.geometryFor(nucleotide, origin)
+            assertTrue(isWithinNucleotideGeometryTestWindow(geometry, origin), "Expected $nucleotide to stay inside the geometry test window")
         }
     }
 
@@ -93,42 +90,26 @@ class NucleotideRendererTest {
 
 
     @Test
-    fun `geometryFor renders rounded protrusions as polygon geometry that extends beyond the base tile`() {
+    fun `geometryFor renders rounded protrusions as polygon geometry that extends beyond the right edge of the base tile`() {
         val origin = Vector2(10f, 20f)
+        val geometry = renderer.geometryFor(Nucleotide.C, origin)
 
-        listOf(PairingSide.LEFT, PairingSide.RIGHT, PairingSide.TOP, PairingSide.BOTTOM).forEach { pairingSide ->
-            val geometry = renderer.geometryFor(Nucleotide.C, origin, NucleotideOrientation(pairingSide))
+        assertTrue(geometry.elements.none { it is Arc }, "Expected rounded protrusion for C to avoid arc primitives")
 
-            assertTrue(geometry.elements.none { it is Arc }, "Expected rounded protrusion for C to avoid arc primitives")
+        val vertices = geometry.elements.filterIsInstance<Polygon>().flatMap { it.vertices }
 
-            val vertices = geometry.elements.filterIsInstance<Polygon>().flatMap { it.vertices }
-
-            when (pairingSide) {
-                PairingSide.LEFT -> assertTrue(
-                    vertices.any { it.x < origin.x },
-                    "Expected left rounded protrusion to extend beyond the left edge",
-                )
-
-                PairingSide.RIGHT -> assertTrue(
-                    vertices.any { it.x > origin.x + renderer.baseSize },
-                    "Expected right rounded protrusion to extend beyond the right edge",
-                )
-
-                PairingSide.TOP -> assertTrue(
-                    vertices.any { it.y > origin.y + renderer.baseSize },
-                    "Expected top rounded protrusion to extend beyond the top edge",
-                )
-
-                PairingSide.BOTTOM -> assertTrue(
-                    vertices.any { it.y < origin.y },
-                    "Expected bottom rounded protrusion to extend beyond the bottom edge",
-                )
-            }
-        }
+        assertTrue(
+            vertices.any { it.x > origin.x + renderer.baseSize },
+            "Expected the rounded protrusion to extend beyond the right edge",
+        )
+        assertTrue(
+            vertices.none { it.x < origin.x },
+            "Expected the rounded protrusion to keep the left edge aligned with the base tile",
+        )
     }
 
     @Test
-    fun `geometryFor renders rounded indentations as a single polygon with an outward concave socket`() {
+    fun `geometryFor renders rounded indentations as a single polygon with an outward concave socket on the right edge`() {
         val origin = Vector2(10f, 20f)
         val baseCorners = listOf(
             Vector2(origin.x, origin.y),
@@ -136,50 +117,18 @@ class NucleotideRendererTest {
             Vector2(origin.x, origin.y + renderer.baseSize),
             Vector2(origin.x + renderer.baseSize, origin.y + renderer.baseSize),
         )
+        val geometry = renderer.geometryFor(Nucleotide.G, origin)
+        val polygon = geometry.elements.filterIsInstance<Polygon>().single()
 
-        listOf(PairingSide.LEFT, PairingSide.RIGHT, PairingSide.TOP, PairingSide.BOTTOM).forEach { pairingSide ->
-            val geometry = renderer.geometryFor(Nucleotide.G, origin, NucleotideOrientation(pairingSide))
-            val polygon = geometry.elements.filterIsInstance<Polygon>().single()
-
-            assertTrue(geometry.elements.none { it is Arc || it is Line })
-            assertTrue(baseCorners.all(polygon.vertices::contains), "Expected the rounded indentation polygon to keep the rectangular body corners")
-            assertTrue(polygon.vertices.first() == polygon.vertices.last(), "Expected the rounded indentation polygon to be closed")
-            assertTrue(polygonArea(polygon.vertices) > renderer.baseSize * renderer.baseSize, "Expected the rounded indentation polygon to cover more area than the base square")
-
-            when (pairingSide) {
-                PairingSide.LEFT -> {
-                    assertTrue(polygon.vertices.any { it.x < origin.x }, "Expected the left rounded socket to extend beyond the left edge")
-                    assertTrue(
-                        polygon.vertices.any { approximatelyEqual(it.x, origin.x) && approximatelyEqual(it.y, origin.y + renderer.baseSize * 0.5f) },
-                        "Expected the left rounded socket to curve back inward to the left body edge",
-                    )
-                }
-
-                PairingSide.RIGHT -> {
-                    assertTrue(polygon.vertices.any { it.x > origin.x + renderer.baseSize }, "Expected the right rounded socket to extend beyond the right edge")
-                    assertTrue(
-                        polygon.vertices.any { approximatelyEqual(it.x, origin.x + renderer.baseSize) && approximatelyEqual(it.y, origin.y + renderer.baseSize * 0.5f) },
-                        "Expected the right rounded socket to curve back inward to the right body edge",
-                    )
-                }
-
-                PairingSide.TOP -> {
-                    assertTrue(polygon.vertices.any { it.y > origin.y + renderer.baseSize }, "Expected the top rounded socket to extend beyond the top edge")
-                    assertTrue(
-                        polygon.vertices.any { approximatelyEqual(it.x, origin.x + renderer.baseSize * 0.5f) && approximatelyEqual(it.y, origin.y + renderer.baseSize) },
-                        "Expected the top rounded socket to curve back inward to the top body edge",
-                    )
-                }
-
-                PairingSide.BOTTOM -> {
-                    assertTrue(polygon.vertices.any { it.y < origin.y }, "Expected the bottom rounded socket to extend beyond the bottom edge")
-                    assertTrue(
-                        polygon.vertices.any { approximatelyEqual(it.x, origin.x + renderer.baseSize * 0.5f) && approximatelyEqual(it.y, origin.y) },
-                        "Expected the bottom rounded socket to curve back inward to the bottom body edge",
-                    )
-                }
-            }
-        }
+        assertTrue(geometry.elements.none { it is Arc || it is Line })
+        assertTrue(baseCorners.all(polygon.vertices::contains), "Expected the rounded indentation polygon to keep the rectangular body corners")
+        assertTrue(polygon.vertices.first() == polygon.vertices.last(), "Expected the rounded indentation polygon to be closed")
+        assertTrue(polygonArea(polygon.vertices) > renderer.baseSize * renderer.baseSize, "Expected the rounded indentation polygon to cover more area than the base square")
+        assertTrue(polygon.vertices.any { it.x > origin.x + renderer.baseSize }, "Expected the rounded socket to extend beyond the right edge")
+        assertTrue(
+            polygon.vertices.any { approximatelyEqual(it.x, origin.x + renderer.baseSize) && approximatelyEqual(it.y, origin.y + renderer.baseSize * 0.5f) },
+            "Expected the rounded socket to curve back inward to the right body edge",
+        )
     }
 
 
@@ -193,17 +142,20 @@ class NucleotideRendererTest {
     }
 
     @Test
-    fun `renderToSpriteCached uses centered sprite origin`() {
+    fun `renderToSpriteCached uses a half-height origin on the left edge of the sprite`() {
         val renderer = NucleotideRenderer(baseSize = 40f)
         val baseSize = renderer.baseSize
         val pairingBandSize = baseSize * 0.5f
-        val spriteSize = baseSize + 2f * pairingBandSize
+        val spriteWidth = kotlin.math.ceil(baseSize * 1.5f)
+        val spriteHeight = kotlin.math.ceil(baseSize)
+        val originX = 0f
+        val originY = baseSize * 0.5f
 
-        val origin = pairingBandSize + baseSize * 0.5f
-
-        assertEquals(baseSize * 0.5f + pairingBandSize, origin)
-        assertEquals(baseSize * 0.5f + pairingBandSize, origin)
-        assertEquals(baseSize + 2f * pairingBandSize, spriteSize)
+        assertEquals(baseSize * 1.5f, spriteWidth)
+        assertEquals(baseSize, spriteHeight)
+        assertEquals(0f, originX)
+        assertEquals(baseSize * 0.5f, originY)
+        assertEquals(baseSize * 0.5f, pairingBandSize)
     }
 
     @Test

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideSequenceRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideSequenceRendererTest.kt
@@ -54,12 +54,23 @@ class NucleotideSequenceRendererTest {
     }
 
     @Test
-    fun `layout places nucleotide row on opposite sides of the backbone for forward and backward directions`() {
-        val forwardLayout = requireNotNull(renderer.layout(NucleotideSequence.parse(">AU>"), Vector2(100f, 50f)))
-        val backwardLayout = requireNotNull(renderer.layout(NucleotideSequence.parse("<AU<"), Vector2(100f, 50f)))
+    fun `layout keeps nucleotide anchors centered and places the direction indicator on the strand-facing side`() {
+        val position = Vector2(100f, 50f)
+        val forwardLayout = requireNotNull(renderer.layout(NucleotideSequence.parse(">AU>"), position))
+        val backwardLayout = requireNotNull(renderer.layout(NucleotideSequence.parse("<AU<"), position))
 
-        assertEquals(40f, forwardLayout.nucleotideAnchors.first().y)
-        assertEquals(60f, backwardLayout.nucleotideAnchors.first().y)
+        assertEquals(position.y, forwardLayout.nucleotideAnchors.first().y)
+        assertEquals(position.y, backwardLayout.nucleotideAnchors.first().y)
+
+        val forwardIndicatorTip = forwardLayout.directionIndicatorVertices.first()
+        val backwardIndicatorTip = backwardLayout.directionIndicatorVertices.first()
+
+        assertEquals(137f, forwardIndicatorTip.x)
+        assertEquals(40f, forwardIndicatorTip.y)
+        assertEquals(63f, backwardIndicatorTip.x)
+        assertEquals(60f, backwardIndicatorTip.y)
+        assertEquals(true, forwardIndicatorTip.x > forwardLayout.backboneEnd.x)
+        assertEquals(true, backwardIndicatorTip.x < backwardLayout.backboneStart.x)
     }
 
     private fun assertVectorEquals(expected: Vector2, actual: Vector2, tolerance: Float = 0.0001f) {

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideSequenceRendererTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/NucleotideSequenceRendererTest.kt
@@ -49,8 +49,8 @@ class NucleotideSequenceRendererTest {
 
     @Test
     fun `nucleotideRotation applies opposite strand-facing offsets for forward and backward sequences`() {
-        assertEquals(300f, renderer.nucleotideRotation(SequenceDirection.FORWARD, 30f))
-        assertEquals(120f, renderer.nucleotideRotation(SequenceDirection.BACKWARD, 30f))
+        assertEquals(270f, renderer.nucleotideRotation(SequenceDirection.FORWARD))
+        assertEquals(90f, renderer.nucleotideRotation(SequenceDirection.BACKWARD))
     }
 
     @Test

--- a/simulator/src/test/kotlin/life/sim/simulator/rendering/SpritesTest.kt
+++ b/simulator/src/test/kotlin/life/sim/simulator/rendering/SpritesTest.kt
@@ -13,11 +13,11 @@ class SpritesTest {
 
         val first = sprites.getOrCreate(SpriteKey("k")) {
             generated += 1
-            CachedSprite(TextureRegion(), 1f, 1f, 0f, 0f, 0f, 0f)
+            CachedSprite(TextureRegion(), 1f, 1f, 0f, 0f)
         }
         val second = sprites.getOrCreate(SpriteKey("k")) {
             generated += 1
-            CachedSprite(TextureRegion(), 1f, 1f, 0f, 0f, 0f, 0f)
+            CachedSprite(TextureRegion(), 1f, 1f, 0f, 0f)
         }
 
         assertSame(first, second)
@@ -30,10 +30,10 @@ class SpritesTest {
         val first = TextureRegion()
         val second = TextureRegion()
 
-        sprites.putRegion(SpriteKey("k"), first, 1f, 1f, 0f, 0f, 0f, 0f)
-        val stored = sprites.putRegion(SpriteKey("k"), second, 1f, 1f, 0f, 0f, 0f, 0f)
+        sprites.putRegion(SpriteKey("k"), first, 1f, 1f, 0f, 0f)
+        val stored = sprites.putRegion(SpriteKey("k"), second, 1f, 1f, 0f, 0f)
 
         assertSame(second, stored.region)
-        assertSame(second, sprites.getOrCreate(SpriteKey("k")) { CachedSprite(TextureRegion(), 1f, 1f, 0f, 0f, 0f, 0f) }.region)
+        assertSame(second, sprites.getOrCreate(SpriteKey("k")) { CachedSprite(TextureRegion(), 1f, 1f, 0f, 0f) }.region)
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a single canonical local-to-world transform for rendering so renderers stop reimplementing ad-hoc position/rotation math.
- Keep `SimWrapper` debuggable with `position` and `rotation` fields while letting renderers work with a cached `Matrix3` transform.
- Reduce per-frame allocations and make composite renderers (nucleotide sequences, DNA) apply the same transform consistently.

### Description
- `SimWrapper` now maintains a cached `Matrix3` (`transform`) updated in `init` and on each `update(...)` and passes it to renderers via `renderer.render(content, transform, context)`.
- The `Renderer` API is now transform-first: `fun render(value: T, transform: Matrix3, context: RenderContext)` with a compatibility overload `render(value, position, rotation, context)` that builds a `Matrix3`.
- Sprite drawing API was updated so `RenderContext.drawSprite` and `Sprites.draw` accept a `Matrix3` and use `Affine2` to apply sprite tile/rotation origins when drawing.
- `NucleotideRenderer`, `NucleotideSequenceRenderer`, `DnaRenderer`, and `Renderers` were refactored to build geometry in local space and convert to world space with the provided matrix, and `SimWrapperTest` gained a `Matrix3` order test to validate translate-then-rotate semantics.

### Testing
- Ran the simulator test suite with `./gradlew :simulator:test` and it completed successfully.
- During the migration I ran targeted tests (`SimWrapperTest`, `NucleotideSequenceRendererTest`, `SpritesTest`); an initial compile error occurred because test render stubs needed updating, that was fixed and the targeted tests then passed.
- All automated simulator tests mentioned above passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86fa237dc83299e4a8217488293fa)