### PR TITLE
Add biology binding availability events and EventVersion helper

### DIFF
--- a/biology/README.md
+++ b/biology/README.md
@@ -16,7 +16,7 @@ Planned components:
 
 ## Binding availability events
 
-The biology module now emits domain event types for binding availability:
+The biology module now defines domain event types for binding availability:
 
 - `BindingEndpointAvailable` for concrete endpoint availability
 - `BindingSurfaceAvailable` for searchable surface availability

--- a/biology/README.md
+++ b/biology/README.md
@@ -12,3 +12,14 @@ Planned components:
 - Resource pools, decay, and recycling helpers
 - Unit tests for interaction and reaction behavior
 
+
+
+## Binding availability events
+
+The biology module now emits domain event types for binding availability:
+
+- `BindingEndpointAvailable` for concrete endpoint availability
+- `BindingSurfaceAvailable` for searchable surface availability
+- `BindingCapabilities` for compatibility metadata (bond types, sequence pattern, affinity)
+
+These events implement the generic `events` module `Event` contract while keeping biology logic simulator-agnostic.

--- a/biology/build.gradle.kts
+++ b/biology/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":events"))
+
     testImplementation(kotlin("test"))
 }
 

--- a/biology/src/main/kotlin/life/sim/biology/events/BindingAvailabilityEvents.kt
+++ b/biology/src/main/kotlin/life/sim/biology/events/BindingAvailabilityEvents.kt
@@ -9,7 +9,13 @@ data class BindingCapabilities(
     val supportedBondTypes: Set<String> = emptySet(),
     val sequencePattern: NucleotideSequence? = null,
     val affinity: Double? = null,
-)
+) {
+    init {
+        require(affinity == null || (affinity.isFinite() && affinity in 0.0..1.0)) {
+            "BindingCapabilities.affinity must be finite and within 0.0..1.0 when provided"
+        }
+    }
+}
 
 data class BindingEndpointAvailable(
     override val id: String,

--- a/biology/src/main/kotlin/life/sim/biology/events/BindingAvailabilityEvents.kt
+++ b/biology/src/main/kotlin/life/sim/biology/events/BindingAvailabilityEvents.kt
@@ -1,0 +1,59 @@
+package life.sim.biology.events
+
+import life.sim.biology.interactions.*
+import life.sim.biology.primitives.NucleotideSequence
+import life.sim.events.Event
+import life.sim.events.EventVersion
+
+data class BindingCapabilities(
+    val supportedBondTypes: Set<String> = emptySet(),
+    val sequencePattern: NucleotideSequence? = null,
+    val affinity: Double? = null,
+)
+
+data class BindingEndpointAvailable(
+    override val id: String,
+    override val source: String,
+    override val parentCorrelationId: String?,
+    override val rootCorrelationId: String,
+    val endpoint: BondEndpoint,
+    val capabilities: BindingCapabilities,
+) : Event {
+    override val type: String = "binding-endpoint-available"
+    override val version: String = V1_0_0.toString()
+    override val topic: String = BINDINGS_TOPIC
+
+    override val routingTags: Set<String> = setOf(
+        BIOLOGY_TAG,
+        BINDINGS_TAG,
+        BINDINGS_AVAILABLE_TAG,
+        "entities/${endpoint.moleculeId.value}/",
+    )
+}
+
+data class BindingSurfaceAvailable(
+    override val id: String,
+    override val source: String,
+    override val parentCorrelationId: String?,
+    override val rootCorrelationId: String,
+    val surface: BindingSurface,
+    val capabilities: BindingCapabilities,
+) : Event {
+    override val type: String = "binding-surface-available"
+    override val version: String = V1_0_0.toString()
+    override val topic: String = BINDINGS_TOPIC
+
+    override val routingTags: Set<String> = setOf(
+        BIOLOGY_TAG,
+        BINDINGS_TAG,
+        BINDINGS_AVAILABLE_TAG,
+        "entities/${surface.moleculeId.value}/",
+    )
+}
+
+private val V1_0_0 = EventVersion(1, 0, 0)
+
+private const val BINDINGS_TOPIC = "biology/bindings/"
+private const val BIOLOGY_TAG = "biology/"
+private const val BINDINGS_TAG = "bindings/"
+private const val BINDINGS_AVAILABLE_TAG = "bindings/available/"

--- a/biology/src/test/kotlin/life/sim/biology/events/BindingAvailabilityEventsTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/events/BindingAvailabilityEventsTest.kt
@@ -1,0 +1,64 @@
+package life.sim.biology.events
+
+import life.sim.biology.interactions.*
+import life.sim.biology.primitives.NucleotideSequence
+import life.sim.events.EventVersion
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BindingAvailabilityEventsTest {
+    @Test
+    fun `BindingEndpointAvailable exposes expected metadata payload and routing tags`() {
+        val event = BindingEndpointAvailable(
+            id = "evt-1",
+            source = "biology-test",
+            parentCorrelationId = "parent-1",
+            rootCorrelationId = "root-1",
+            endpoint = WholeMoleculeEndpoint(MoleculeId(123)),
+            capabilities = BindingCapabilities(
+                supportedBondTypes = setOf("hydrogen"),
+                sequencePattern = NucleotideSequence.parse("AUGC"),
+                affinity = 0.75,
+            ),
+        )
+
+        assertEquals("binding-endpoint-available", event.type)
+        assertEquals("1.0.0", event.version)
+        assertEquals(EventVersion(1, 0, 0), EventVersion.parse(event.version))
+        assertEquals("biology/bindings/", event.topic)
+        assertEquals(
+            setOf("biology/", "bindings/", "bindings/available/", "entities/123/"),
+            event.routingTags,
+        )
+        assertEquals(MoleculeId(123), event.endpoint.moleculeId)
+        assertEquals(setOf("hydrogen"), event.capabilities.supportedBondTypes)
+    }
+
+    @Test
+    fun `BindingSurfaceAvailable exposes expected metadata payload and routing tags`() {
+        val event = BindingSurfaceAvailable(
+            id = "evt-2",
+            source = "biology-test",
+            parentCorrelationId = null,
+            rootCorrelationId = "root-2",
+            surface = BindingSurface(
+                moleculeId = MoleculeId(999),
+                strand = BindingStrand.SINGLE,
+                sequence = NucleotideSequence.parse("GGCA"),
+            ),
+            capabilities = BindingCapabilities(affinity = 0.4),
+        )
+
+        assertEquals("binding-surface-available", event.type)
+        assertEquals("1.0.0", event.version)
+        assertTrue(EventVersion.parse(event.version).major == 1)
+        assertEquals("biology/bindings/", event.topic)
+        assertEquals(
+            setOf("biology/", "bindings/", "bindings/available/", "entities/999/"),
+            event.routingTags,
+        )
+        assertEquals(MoleculeId(999), event.surface.moleculeId)
+        assertEquals(0.4, event.capabilities.affinity)
+    }
+}

--- a/events/README.md
+++ b/events/README.md
@@ -28,3 +28,8 @@ is designed to be reused by both modules and by future transports/recorders.
 - filtering by routing tag prefix,
 - combined topic + routing tag filtering,
 - unsubscribing.
+
+
+## Event version helper
+
+Use `EventVersion(major, minor, revision)` and `EventVersion.parse("x.y.z")` to consistently format and validate event version strings while concrete events still expose `Event.version` as `String`.

--- a/events/src/main/kotlin/life/sim/events/EventVersion.kt
+++ b/events/src/main/kotlin/life/sim/events/EventVersion.kt
@@ -1,0 +1,29 @@
+package life.sim.events
+
+data class EventVersion(
+    val major: Int,
+    val minor: Int,
+    val revision: Int,
+) {
+    init {
+        require(major >= 0) { "Event version major must be non-negative, but was $major." }
+        require(minor >= 0) { "Event version minor must be non-negative, but was $minor." }
+        require(revision >= 0) { "Event version revision must be non-negative, but was $revision." }
+    }
+
+    override fun toString(): String = "$major.$minor.$revision"
+
+    companion object {
+        private val versionPattern = Regex("^(\\d+)\\.(\\d+)\\.(\\d+)$")
+
+        fun parse(value: String): EventVersion {
+            val match = versionPattern.matchEntire(value)
+                ?: throw IllegalArgumentException(
+                    "Event version must match [major].[minor].[revision], but was '$value'.",
+                )
+
+            val (major, minor, revision) = match.destructured
+            return EventVersion(major.toInt(), minor.toInt(), revision.toInt())
+        }
+    }
+}

--- a/events/src/test/kotlin/life/sim/events/EventVersionTest.kt
+++ b/events/src/test/kotlin/life/sim/events/EventVersionTest.kt
@@ -1,0 +1,26 @@
+package life.sim.events
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class EventVersionTest {
+    @Test
+    fun `toString renders major minor revision format`() {
+        assertEquals("1.2.3", EventVersion(1, 2, 3).toString())
+    }
+
+    @Test
+    fun `parse accepts major minor revision format`() {
+        val parsed = EventVersion.parse("2.10.7")
+
+        assertEquals(EventVersion(2, 10, 7), parsed)
+    }
+
+    @Test
+    fun `parse rejects invalid version format`() {
+        assertFailsWith<IllegalArgumentException> {
+            EventVersion.parse("1.0")
+        }
+    }
+}

--- a/events/src/test/kotlin/life/sim/events/EventVersionTest.kt
+++ b/events/src/test/kotlin/life/sim/events/EventVersionTest.kt
@@ -23,4 +23,17 @@ class EventVersionTest {
             EventVersion.parse("1.0")
         }
     }
+
+    @Test
+    fun `constructor rejects negative version components`() {
+        assertFailsWith<IllegalArgumentException> {
+            EventVersion(-1, 0, 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            EventVersion(0, -1, 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            EventVersion(0, 0, -1)
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

- Introduce a small, stable event vocabulary so biology can announce binding availability before wiring into simulator control flow. 
- Provide a minimal `BindingCapabilities` model to express biological compatibility (bond types, sequence pattern, affinity). 
- Add a small `EventVersion` helper to standardize `major.minor.revision` version strings for events.

### Description

- Add `BindingEndpointAvailable` and `BindingSurfaceAvailable` event types in `biology` that implement the generic `Event` contract and expose `type` values in kebab-case. 
- Add `BindingCapabilities` to carry compatibility metadata used by the new events. 
- Add `EventVersion` helper in the `events` module with `toString()` and `parse()` for the `major.minor.revision` format and use it to set event version `1.0.0`. 
- Use a single topic `biology/bindings/` and routing tags including `biology/`, `bindings/`, `bindings/available/`, and `entities/{moleculeId}/`, add `biology` → `events` module dependency, and update READMEs.

### Testing

- Ran `./gradlew :events:test :biology:test` and the test suites completed successfully. 
- Added unit tests that verify event metadata, topic, routing tags, version format parsing, and payload fields for the new events and `EventVersion` helper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0418df354c8329a520bf7da9079966)