### PR TITLE
Rename MoleculeId to EntityId across interactions, tests, and docs

### DIFF
--- a/biology/src/main/kotlin/life/sim/biology/interactions/BindingSite.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BindingSite.kt
@@ -16,7 +16,7 @@ data class BindingSite(
         }
     }
 
-    val moleculeId: MoleculeId
+    val moleculeId: EntityId
         get() = surface.moleculeId
 
     val strand: BindingStrand

--- a/biology/src/main/kotlin/life/sim/biology/interactions/BindingSurface.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BindingSurface.kt
@@ -7,7 +7,7 @@ import life.sim.biology.primitives.SequenceRange
  * An addressable strand of a molecule that can host bonds.
  */
 data class BindingSurface(
-    val moleculeId: MoleculeId,
+    val moleculeId: EntityId,
     val strand: BindingStrand,
     val sequence: NucleotideSequence,
 ) {

--- a/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/Bond.kt
@@ -4,7 +4,7 @@ package life.sim.biology.interactions
  * One endpoint of a runtime molecule association.
  */
 sealed interface BondEndpoint {
-    val moleculeId: MoleculeId
+    val moleculeId: EntityId
     val site: BindingSite?
 }
 
@@ -12,7 +12,7 @@ sealed interface BondEndpoint {
  * Endpoint that references only a whole molecule instance.
  */
 data class WholeMoleculeEndpoint(
-    override val moleculeId: MoleculeId,
+    override val moleculeId: EntityId,
 ) : BondEndpoint {
     override val site: BindingSite? = null
 }
@@ -23,7 +23,7 @@ data class WholeMoleculeEndpoint(
 data class SiteEndpoint(
     override val site: BindingSite,
 ) : BondEndpoint {
-    override val moleculeId: MoleculeId
+    override val moleculeId: EntityId
         get() = site.moleculeId
 }
 
@@ -47,7 +47,7 @@ data class Bond(
 
     fun isActive(): Boolean = strength > 0.0
 
-    fun involves(moleculeId: MoleculeId): Boolean =
+    fun involves(moleculeId: EntityId): Boolean =
         left.moleculeId == moleculeId || right.moleculeId == moleculeId
 
     fun bindingSites(): List<BindingSite> =

--- a/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/BondRegistry.kt
@@ -30,7 +30,7 @@ class BondRegistry(
 
     fun toList(): List<Bond> = bonds.toList()
 
-    fun bondsFor(moleculeId: MoleculeId): List<Bond> = bonds.filter { it.involves(moleculeId) }
+    fun bondsFor(moleculeId: EntityId): List<Bond> = bonds.filter { it.involves(moleculeId) }
 
     fun bondsInvolving(site: BindingSite): List<Bond> =
         bonds.filter { bond -> bond.bindingSites().any { it == site } }

--- a/biology/src/main/kotlin/life/sim/biology/interactions/EntityId.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/EntityId.kt
@@ -1,0 +1,7 @@
+package life.sim.biology.interactions
+
+/**
+ * Stable runtime identifier for biology entities managed in the runtime environment.
+ */
+@JvmInline
+value class EntityId(val value: Long)

--- a/biology/src/main/kotlin/life/sim/biology/interactions/MoleculeBindingSites.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/MoleculeBindingSites.kt
@@ -4,15 +4,15 @@ import life.sim.biology.molecules.Dna
 import life.sim.biology.molecules.MRna
 import life.sim.biology.molecules.TRna
 
-fun Dna.forwardBindingSurface(id: MoleculeId): BindingSurface =
+fun Dna.forwardBindingSurface(id: EntityId): BindingSurface =
     BindingSurface(id, BindingStrand.FORWARD, forward)
 
-fun Dna.reverseBindingSurface(id: MoleculeId): BindingSurface =
+fun Dna.reverseBindingSurface(id: EntityId): BindingSurface =
     BindingSurface(id, BindingStrand.REVERSE, reverse)
 
-fun MRna.bindingSurface(id: MoleculeId): BindingSurface =
+fun MRna.bindingSurface(id: EntityId): BindingSurface =
     BindingSurface(id, BindingStrand.SINGLE, toNucleotideSequence())
 
-fun TRna.bindingSurface(id: MoleculeId): BindingSurface =
+fun TRna.bindingSurface(id: EntityId): BindingSurface =
     BindingSurface(id, BindingStrand.SINGLE, toNucleotideSequence())
 

--- a/biology/src/main/kotlin/life/sim/biology/interactions/MoleculeId.kt
+++ b/biology/src/main/kotlin/life/sim/biology/interactions/MoleculeId.kt
@@ -1,8 +1,0 @@
-package life.sim.biology.interactions
-
-/**
- * Stable identifier for a molecule instance in runtime interaction state.
- */
-@JvmInline
-value class MoleculeId(val value: Long)
-

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ActiveProtein.kt
@@ -1,6 +1,6 @@
 package life.sim.biology.proteins
 
-import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.interactions.EntityId
 import life.sim.biology.molecules.Polypeptide
 import java.util.Collections
 import kotlin.ConsistentCopyVisibility
@@ -10,7 +10,7 @@ import kotlin.ConsistentCopyVisibility
  */
 @ConsistentCopyVisibility
 data class ActiveProtein private constructor(
-    val moleculeId: MoleculeId,
+    val moleculeId: EntityId,
     val source: Polypeptide,
     val domains: List<ProteinDomain>,
 ) {
@@ -22,7 +22,7 @@ data class ActiveProtein private constructor(
          * Creates an [ActiveProtein] from already interpreted [domains] and flattens capability access.
          */
         fun fromDomains(
-            moleculeId: MoleculeId,
+            moleculeId: EntityId,
             source: Polypeptide,
             domains: List<ProteinDomain>,
         ): ActiveProtein {
@@ -45,7 +45,7 @@ data class ActiveProtein private constructor(
          * Interprets [source] and returns a first-class runtime protein molecule.
          */
         fun interpret(
-            moleculeId: MoleculeId,
+            moleculeId: EntityId,
             source: Polypeptide,
         ): ActiveProtein = fromDomains(
             moleculeId = moleculeId,

--- a/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
+++ b/biology/src/main/kotlin/life/sim/biology/proteins/ProteinBinding.kt
@@ -4,7 +4,7 @@ import life.sim.biology.interactions.BindingMatcher
 import life.sim.biology.interactions.BindingSurface
 import life.sim.biology.interactions.Bond
 import life.sim.biology.interactions.BondRegistry
-import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.interactions.EntityId
 import life.sim.biology.interactions.SiteEndpoint
 import life.sim.biology.interactions.WholeMoleculeEndpoint
 
@@ -16,7 +16,7 @@ object ProteinBinding {
     private const val CONFLICT_EPSILON = 1.0e-9
 
     fun tryBind(
-        proteinId: MoleculeId,
+        proteinId: EntityId,
         binder: SequenceBinder,
         target: BindingSurface,
         registry: BondRegistry,

--- a/biology/src/test/kotlin/life/sim/biology/events/BindingAvailabilityEventsTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/events/BindingAvailabilityEventsTest.kt
@@ -15,7 +15,7 @@ class BindingAvailabilityEventsTest {
             source = "biology-test",
             parentCorrelationId = "parent-1",
             rootCorrelationId = "root-1",
-            endpoint = WholeMoleculeEndpoint(MoleculeId(123)),
+            endpoint = WholeMoleculeEndpoint(EntityId(123)),
             capabilities = BindingCapabilities(
                 supportedBondTypes = setOf("hydrogen"),
                 sequencePattern = NucleotideSequence.parse("AUGC"),
@@ -31,7 +31,7 @@ class BindingAvailabilityEventsTest {
             setOf("biology/", "bindings/", "bindings/available/", "entities/123/"),
             event.routingTags,
         )
-        assertEquals(MoleculeId(123), event.endpoint.moleculeId)
+        assertEquals(EntityId(123), event.endpoint.moleculeId)
         assertEquals(setOf("hydrogen"), event.capabilities.supportedBondTypes)
     }
 
@@ -43,7 +43,7 @@ class BindingAvailabilityEventsTest {
             parentCorrelationId = null,
             rootCorrelationId = "root-2",
             surface = BindingSurface(
-                moleculeId = MoleculeId(999),
+                moleculeId = EntityId(999),
                 strand = BindingStrand.SINGLE,
                 sequence = NucleotideSequence.parse("GGCA"),
             ),
@@ -58,7 +58,7 @@ class BindingAvailabilityEventsTest {
             setOf("biology/", "bindings/", "bindings/available/", "entities/999/"),
             event.routingTags,
         )
-        assertEquals(MoleculeId(999), event.surface.moleculeId)
+        assertEquals(EntityId(999), event.surface.moleculeId)
         assertEquals(0.4, event.capabilities.affinity)
     }
 }

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BindingMatcherTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BindingMatcherTest.kt
@@ -25,12 +25,12 @@ class BindingMatcherTest {
 
     @Test
     fun `complementary match site returns a binding site on the target surface`() {
-        val surface = MRna.of("CCUACUAC").bindingSurface(MoleculeId(7))
+        val surface = MRna.of("CCUACUAC").bindingSurface(EntityId(7))
 
         val site = BindingMatcher.complementaryMatchSite(NucleotideSequence.of("AUG"), surface)
 
         assertNotNull(site)
-        assertEquals(MoleculeId(7), site.moleculeId)
+        assertEquals(EntityId(7), site.moleculeId)
         assertEquals(2, site.range.start)
         assertEquals(5, site.range.endExclusive)
         assertEquals(NucleotideSequence.of("UAC"), site.sequence)
@@ -38,7 +38,7 @@ class BindingMatcherTest {
 
     @Test
     fun `complementary match site returns null when no match exists`() {
-        val surface = MRna.of("CGUAAA").bindingSurface(MoleculeId(8))
+        val surface = MRna.of("CGUAAA").bindingSurface(EntityId(8))
 
         assertNull(BindingMatcher.complementaryMatchSite(NucleotideSequence.of("ACG"), surface))
     }
@@ -46,7 +46,7 @@ class BindingMatcherTest {
     @Test
     fun `complementary match sites yields sites in deterministic left to right order`() {
         val pattern = NucleotideSequence.of("AUG")
-        val surface = MRna.of("GGUACUACAA").bindingSurface(MoleculeId(9))
+        val surface = MRna.of("GGUACUACAA").bindingSurface(EntityId(9))
 
         val sites = BindingMatcher.complementaryMatchSites(pattern, surface).toList()
 

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BindingSiteTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BindingSiteTest.kt
@@ -15,10 +15,10 @@ import kotlin.test.assertTrue
 class BindingSiteTest {
     @Test
     fun `mrna binding surface creates single strand sites`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(1))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(1))
         val site = surface.site(1, 4)
 
-        assertEquals(MoleculeId(1), site.moleculeId)
+        assertEquals(EntityId(1), site.moleculeId)
         assertEquals(BindingStrand.SINGLE, site.strand)
         assertEquals(NucleotideSequence.of("UGC"), site.sequence)
     }
@@ -27,13 +27,13 @@ class BindingSiteTest {
     fun `dna exposes forward and reverse binding surfaces`() {
         val dna = Dna.of("AUGC", "UACG")
 
-        assertEquals(NucleotideSequence.parse(">AUGC>"), dna.forwardBindingSurface(MoleculeId(2)).sequence)
-        assertEquals(NucleotideSequence.parse("<UACG<"), dna.reverseBindingSurface(MoleculeId(2)).sequence)
+        assertEquals(NucleotideSequence.parse(">AUGC>"), dna.forwardBindingSurface(EntityId(2)).sequence)
+        assertEquals(NucleotideSequence.parse("<UACG<"), dna.reverseBindingSurface(EntityId(2)).sequence)
     }
 
     @Test
     fun `trna binding surface uses a single strand`() {
-        val surface = TRna.of("CGAU").bindingSurface(MoleculeId(3))
+        val surface = TRna.of("CGAU").bindingSurface(EntityId(3))
 
         assertEquals(BindingStrand.SINGLE, surface.strand)
         assertEquals(NucleotideSequence.of("CGAU"), surface.sequence)
@@ -42,10 +42,10 @@ class BindingSiteTest {
     @Test
     fun `sites overlap only on the same molecule and strand`() {
         val mrna = MRna.of("AUGCUA")
-        val first = mrna.bindingSurface(MoleculeId(4)).site(1, 4)
-        val overlapping = mrna.bindingSurface(MoleculeId(4)).site(3, 6)
-        val sameRangeDifferentMolecule = mrna.bindingSurface(MoleculeId(5)).site(3, 6)
-        val reverseDnaSite = Dna.of("AUGCUA", "UACGAU").reverseBindingSurface(MoleculeId(4)).site(3, 6)
+        val first = mrna.bindingSurface(EntityId(4)).site(1, 4)
+        val overlapping = mrna.bindingSurface(EntityId(4)).site(3, 6)
+        val sameRangeDifferentMolecule = mrna.bindingSurface(EntityId(5)).site(3, 6)
+        val reverseDnaSite = Dna.of("AUGCUA", "UACGAU").reverseBindingSurface(EntityId(4)).site(3, 6)
 
         assertTrue(first.overlaps(overlapping))
         assertFalse(first.overlaps(sameRangeDifferentMolecule))
@@ -54,7 +54,7 @@ class BindingSiteTest {
 
     @Test
     fun `empty sites never overlap`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(7))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(7))
         val empty = surface.site(5, 5)
         val occupied = surface.site(4, 6)
 
@@ -65,7 +65,7 @@ class BindingSiteTest {
 
     @Test
     fun `site rejects ranges beyond the surface length`() {
-        val surface = MRna.of("AUGC").bindingSurface(MoleculeId(6))
+        val surface = MRna.of("AUGC").bindingSurface(EntityId(6))
 
         val exception = assertFailsWith<IllegalArgumentException> {
             BindingSite(surface, SequenceRange(1, 5))

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondRegistryTest.kt
@@ -11,8 +11,8 @@ import kotlin.test.assertTrue
 class BondRegistryTest {
     @Test
     fun `registry supports site to site, site to whole, and whole to whole bonds`() {
-        val firstSurface = MRna.of("AUGCUA").bindingSurface(MoleculeId(11))
-        val secondSurface = MRna.of("CGAAUU").bindingSurface(MoleculeId(12))
+        val firstSurface = MRna.of("AUGCUA").bindingSurface(EntityId(11))
+        val secondSurface = MRna.of("CGAAUU").bindingSurface(EntityId(12))
 
         val siteToSite = Bond(
             left = SiteEndpoint(firstSurface.site(1, 4)),
@@ -22,36 +22,36 @@ class BondRegistryTest {
         )
         val siteToWhole = Bond(
             left = SiteEndpoint(firstSurface.site(4, 6)),
-            right = WholeMoleculeEndpoint(MoleculeId(13)),
+            right = WholeMoleculeEndpoint(EntityId(13)),
             strength = 0.9,
             decayPerTick = 0.2,
         )
         val wholeToWhole = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(13)),
-            right = WholeMoleculeEndpoint(MoleculeId(14)),
+            left = WholeMoleculeEndpoint(EntityId(13)),
+            right = WholeMoleculeEndpoint(EntityId(14)),
             strength = 0.7,
             decayPerTick = 0.05,
         )
 
         val registry = BondRegistry(listOf(siteToSite, siteToWhole, wholeToWhole))
 
-        assertEquals(listOf(siteToSite, siteToWhole), registry.bondsFor(MoleculeId(11)))
-        assertEquals(listOf(siteToWhole, wholeToWhole), registry.bondsFor(MoleculeId(13)))
-        assertEquals(listOf(wholeToWhole), registry.bondsFor(MoleculeId(14)))
+        assertEquals(listOf(siteToSite, siteToWhole), registry.bondsFor(EntityId(11)))
+        assertEquals(listOf(siteToWhole, wholeToWhole), registry.bondsFor(EntityId(13)))
+        assertEquals(listOf(wholeToWhole), registry.bondsFor(EntityId(14)))
     }
 
     @Test
     fun `registry overlap queries only consider site-aware endpoints`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(17))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(17))
         val siteToWhole = Bond(
             left = SiteEndpoint(surface.site(1, 4)),
-            right = WholeMoleculeEndpoint(MoleculeId(21)),
+            right = WholeMoleculeEndpoint(EntityId(21)),
             strength = 0.9,
             decayPerTick = 0.2,
         )
         val wholeToWhole = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(21)),
-            right = WholeMoleculeEndpoint(MoleculeId(22)),
+            left = WholeMoleculeEndpoint(EntityId(21)),
+            right = WholeMoleculeEndpoint(EntityId(22)),
             strength = 0.9,
             decayPerTick = 0.2,
         )
@@ -59,36 +59,36 @@ class BondRegistryTest {
 
         assertEquals(listOf(siteToWhole), registry.overlapping(surface.site(2, 3)))
         assertTrue(registry.overlapping(surface.site(5, 5)).isEmpty())
-        assertTrue(registry.overlapping(MRna.of("CC").bindingSurface(MoleculeId(22)).site(0, 2)).isEmpty())
+        assertTrue(registry.overlapping(MRna.of("CC").bindingSurface(EntityId(22)).site(0, 2)).isEmpty())
     }
 
     @Test
     fun `registry can query bonds by exact site and by surface`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(15))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(15))
         val exactSite = surface.site(1, 4)
         val otherSite = surface.site(4, 6)
         val rightOnlySite = surface.site(0, 2)
         val first = Bond(
             left = SiteEndpoint(exactSite),
-            right = WholeMoleculeEndpoint(MoleculeId(99)),
+            right = WholeMoleculeEndpoint(EntityId(99)),
             strength = 0.8,
             decayPerTick = 0.1,
         )
         val second = Bond(
             left = SiteEndpoint(otherSite),
-            right = WholeMoleculeEndpoint(MoleculeId(100)),
+            right = WholeMoleculeEndpoint(EntityId(100)),
             strength = 0.8,
             decayPerTick = 0.1,
         )
         val siteOnRight = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(102)),
+            left = WholeMoleculeEndpoint(EntityId(102)),
             right = SiteEndpoint(rightOnlySite),
             strength = 0.8,
             decayPerTick = 0.1,
         )
         val wholeOnly = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(15)),
-            right = WholeMoleculeEndpoint(MoleculeId(101)),
+            left = WholeMoleculeEndpoint(EntityId(15)),
+            right = WholeMoleculeEndpoint(EntityId(101)),
             strength = 0.8,
             decayPerTick = 0.1,
         )
@@ -102,16 +102,16 @@ class BondRegistryTest {
 
     @Test
     fun `registry ignores inactive bonds supplied at construction`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(15))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(15))
         val active = Bond(
             left = SiteEndpoint(surface.site(1, 4)),
-            right = WholeMoleculeEndpoint(MoleculeId(31)),
+            right = WholeMoleculeEndpoint(EntityId(31)),
             strength = 0.8,
             decayPerTick = 0.1,
         )
         val inactive = Bond(
             left = SiteEndpoint(surface.site(4, 6)),
-            right = WholeMoleculeEndpoint(MoleculeId(32)),
+            right = WholeMoleculeEndpoint(EntityId(32)),
             strength = 0.0,
             decayPerTick = 0.2,
         )
@@ -119,17 +119,17 @@ class BondRegistryTest {
         val registry = BondRegistry(listOf(active, inactive))
 
         assertEquals(listOf(active), registry.toList())
-        assertEquals(listOf(active), registry.bondsFor(MoleculeId(15)))
+        assertEquals(listOf(active), registry.bondsFor(EntityId(15)))
         assertTrue(registry.overlapping(surface.site(4, 6)).isEmpty())
         assertEquals(listOf(active), registry.bondsOnSurface(surface.site(0, 1)))
     }
 
     @Test
     fun `registry add ignores inactive bonds`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(16))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(16))
         val inactive = Bond(
             left = SiteEndpoint(surface.site(1, 4)),
-            right = WholeMoleculeEndpoint(MoleculeId(90)),
+            right = WholeMoleculeEndpoint(EntityId(90)),
             strength = 0.0,
             decayPerTick = 0.1,
         )
@@ -139,17 +139,17 @@ class BondRegistryTest {
 
         assertEquals(inactive, returned)
         assertTrue(registry.isEmpty())
-        assertTrue(registry.bondsFor(MoleculeId(16)).isEmpty())
+        assertTrue(registry.bondsFor(EntityId(16)).isEmpty())
         assertTrue(registry.bondsOnSurface(surface.site(0, 1)).isEmpty())
         assertTrue(registry.overlapping(surface.site(1, 4)).isEmpty())
     }
 
     @Test
     fun `registry stores only one active entry for mirrored bonds`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(18))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(18))
         val bond = Bond(
             left = SiteEndpoint(surface.site(1, 4)),
-            right = WholeMoleculeEndpoint(MoleculeId(23)),
+            right = WholeMoleculeEndpoint(EntityId(23)),
             strength = 0.9,
             decayPerTick = 0.1,
         )
@@ -170,16 +170,16 @@ class BondRegistryTest {
 
     @Test
     fun `registry iterator is a snapshot and is unaffected by later mutations`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(24))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(24))
         val first = Bond(
             left = SiteEndpoint(surface.site(0, 2)),
-            right = WholeMoleculeEndpoint(MoleculeId(25)),
+            right = WholeMoleculeEndpoint(EntityId(25)),
             strength = 0.8,
             decayPerTick = 0.1,
         )
         val second = Bond(
             left = SiteEndpoint(surface.site(2, 4)),
-            right = WholeMoleculeEndpoint(MoleculeId(26)),
+            right = WholeMoleculeEndpoint(EntityId(26)),
             strength = 0.7,
             decayPerTick = 0.1,
         )
@@ -194,16 +194,16 @@ class BondRegistryTest {
 
     @Test
     fun `registry decay removes inactive bonds and keeps surviving strength`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(12))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(12))
         val transient = Bond(
             left = SiteEndpoint(surface.site(0, 2)),
-            right = WholeMoleculeEndpoint(MoleculeId(41)),
+            right = WholeMoleculeEndpoint(EntityId(41)),
             strength = 0.1,
             decayPerTick = 0.1,
         )
         val stable = Bond(
             left = SiteEndpoint(surface.site(2, 5)),
-            right = WholeMoleculeEndpoint(MoleculeId(42)),
+            right = WholeMoleculeEndpoint(EntityId(42)),
             strength = 0.9,
             decayPerTick = 0.2,
         )
@@ -219,8 +219,8 @@ class BondRegistryTest {
     @Test
     fun `bond decay rejects negative tick counts`() {
         val bond = Bond(
-            left = SiteEndpoint(MRna.of("AUG").bindingSurface(MoleculeId(13)).site(0, 2)),
-            right = WholeMoleculeEndpoint(MoleculeId(50)),
+            left = SiteEndpoint(MRna.of("AUG").bindingSurface(EntityId(13)).site(0, 2)),
+            right = WholeMoleculeEndpoint(EntityId(50)),
             strength = 1.0,
             decayPerTick = 0.1,
         )
@@ -235,8 +235,8 @@ class BondRegistryTest {
     @Test
     fun `bond reports whether it is still active`() {
         val bond = Bond(
-            left = SiteEndpoint(MRna.of("AUG").bindingSurface(MoleculeId(14)).site(0, 2)),
-            right = WholeMoleculeEndpoint(MoleculeId(51)),
+            left = SiteEndpoint(MRna.of("AUG").bindingSurface(EntityId(14)).site(0, 2)),
+            right = WholeMoleculeEndpoint(EntityId(51)),
             strength = 0.0,
             decayPerTick = 0.1,
         )

--- a/biology/src/test/kotlin/life/sim/biology/interactions/BondTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/interactions/BondTest.kt
@@ -9,8 +9,8 @@ import kotlin.test.assertNotEquals
 class BondTest {
     @Test
     fun `swapped site to site endpoints compare equal and share hash code`() {
-        val firstSurface = MRna.of("AUGCUA").bindingSurface(MoleculeId(1))
-        val secondSurface = MRna.of("CGAAUU").bindingSurface(MoleculeId(2))
+        val firstSurface = MRna.of("AUGCUA").bindingSurface(EntityId(1))
+        val secondSurface = MRna.of("CGAAUU").bindingSurface(EntityId(2))
 
         val first = Bond(
             left = SiteEndpoint(firstSurface.site(1, 4)),
@@ -31,10 +31,10 @@ class BondTest {
 
     @Test
     fun `swapped site to whole endpoints compare equal and share hash code`() {
-        val surface = MRna.of("AUGCUA").bindingSurface(MoleculeId(3))
+        val surface = MRna.of("AUGCUA").bindingSurface(EntityId(3))
         val siteToWhole = Bond(
             left = SiteEndpoint(surface.site(2, 5)),
-            right = WholeMoleculeEndpoint(MoleculeId(4)),
+            right = WholeMoleculeEndpoint(EntityId(4)),
             strength = 0.7,
             decayPerTick = 0.05,
         )
@@ -52,8 +52,8 @@ class BondTest {
     @Test
     fun `swapped whole to whole endpoints compare equal and share hash code`() {
         val first = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(9)),
-            right = WholeMoleculeEndpoint(MoleculeId(10)),
+            left = WholeMoleculeEndpoint(EntityId(9)),
+            right = WholeMoleculeEndpoint(EntityId(10)),
             strength = 0.6,
             decayPerTick = 0.03,
         )
@@ -71,8 +71,8 @@ class BondTest {
     @Test
     fun `different strength still makes mirrored bonds unequal`() {
         val first = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(11)),
-            right = WholeMoleculeEndpoint(MoleculeId(12)),
+            left = WholeMoleculeEndpoint(EntityId(11)),
+            right = WholeMoleculeEndpoint(EntityId(12)),
             strength = 0.6,
             decayPerTick = 0.03,
         )
@@ -89,8 +89,8 @@ class BondTest {
     @Test
     fun `different decay still makes mirrored bonds unequal`() {
         val first = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(13)),
-            right = WholeMoleculeEndpoint(MoleculeId(14)),
+            left = WholeMoleculeEndpoint(EntityId(13)),
+            right = WholeMoleculeEndpoint(EntityId(14)),
             strength = 0.6,
             decayPerTick = 0.03,
         )
@@ -107,14 +107,14 @@ class BondTest {
     @Test
     fun `signed zero values are compared consistently with hash code`() {
         val positiveZeroStrength = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(15)),
-            right = WholeMoleculeEndpoint(MoleculeId(16)),
+            left = WholeMoleculeEndpoint(EntityId(15)),
+            right = WholeMoleculeEndpoint(EntityId(16)),
             strength = 0.0,
             decayPerTick = 0.1,
         )
         val negativeZeroStrength = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(16)),
-            right = WholeMoleculeEndpoint(MoleculeId(15)),
+            left = WholeMoleculeEndpoint(EntityId(16)),
+            right = WholeMoleculeEndpoint(EntityId(15)),
             strength = -0.0,
             decayPerTick = 0.1,
         )

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ActiveProteinTest.kt
@@ -1,6 +1,6 @@
 package life.sim.biology.proteins
 
-import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.interactions.EntityId
 import life.sim.biology.molecules.Polypeptide
 import life.sim.biology.primitives.NucleotideSequence
 
@@ -37,12 +37,12 @@ class ActiveProteinTest {
         )
 
         val activeProtein = ActiveProtein.fromDomains(
-            moleculeId = MoleculeId(42),
+            moleculeId = EntityId(42),
             source = source,
             domains = domains,
         )
 
-        assertEquals(MoleculeId(42), activeProtein.moleculeId)
+        assertEquals(EntityId(42), activeProtein.moleculeId)
         assertEquals(source, activeProtein.source)
         assertEquals(domains, activeProtein.domains)
         assertEquals(domains.flatMap(ProteinDomain::capabilities), activeProtein.capabilities)
@@ -53,11 +53,11 @@ class ActiveProteinTest {
         val source = Polypeptide.of("AAKRGKTTHEMHPPW")
 
         val activeProtein = ActiveProtein.interpret(
-            moleculeId = MoleculeId(9),
+            moleculeId = EntityId(9),
             source = source,
         )
 
-        assertEquals(MoleculeId(9), activeProtein.moleculeId)
+        assertEquals(EntityId(9), activeProtein.moleculeId)
         assertEquals(source, activeProtein.source)
         assertEquals(ProteinInterpreter.interpret(source), activeProtein.domains)
         assertEquals(activeProtein.domains.flatMap(ProteinDomain::capabilities), activeProtein.capabilities)
@@ -83,7 +83,7 @@ class ActiveProteinTest {
         )
 
         val activeProtein = ActiveProtein.fromDomains(
-            moleculeId = MoleculeId(77),
+            moleculeId = EntityId(77),
             source = source,
             domains = mutableDomains,
         )
@@ -127,7 +127,7 @@ class ActiveProteinTest {
         )
 
         val activeProtein = ActiveProtein.fromDomains(
-            moleculeId = MoleculeId(88),
+            moleculeId = EntityId(88),
             source = source,
             domains = mutableDomains,
         )
@@ -146,7 +146,7 @@ class ActiveProteinTest {
     fun `fromDomains exposes unmodifiable domain and capability lists`() {
         val source = Polypeptide.of("AAKRGKTTHEMH")
         val activeProtein = ActiveProtein.fromDomains(
-            moleculeId = MoleculeId(99),
+            moleculeId = EntityId(99),
             source = source,
             domains = listOf(
                 ProteinDomain(

--- a/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
+++ b/biology/src/test/kotlin/life/sim/biology/proteins/ProteinBindingTest.kt
@@ -3,7 +3,7 @@ package life.sim.biology.proteins
 import life.sim.biology.interactions.BindingMatcher
 import life.sim.biology.interactions.Bond
 import life.sim.biology.interactions.BondRegistry
-import life.sim.biology.interactions.MoleculeId
+import life.sim.biology.interactions.EntityId
 import life.sim.biology.interactions.SiteEndpoint
 import life.sim.biology.interactions.WholeMoleculeEndpoint
 import life.sim.biology.interactions.bindingSurface
@@ -21,11 +21,11 @@ class ProteinBindingTest {
     @Test
     fun `interpreted binder can create a runtime bond and register it`() {
         val binder = interpretedBinderFrom("AAKRGKAA")
-        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(20))
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(EntityId(20))
         val registry = BondRegistry()
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(99),
+            proteinId = EntityId(99),
             binder = binder,
             target = target,
             registry = registry,
@@ -36,18 +36,18 @@ class ProteinBindingTest {
         assertEquals(bond, registry.toList().single())
         assertTrue(bond.strength in 0.0..1.0)
         assertEquals(0.05, bond.decayPerTick, absoluteTolerance = 1.0e-9)
-        assertEquals(MoleculeId(99), bond.left.moleculeId)
-        assertEquals(MoleculeId(20), bond.right.moleculeId)
+        assertEquals(EntityId(99), bond.left.moleculeId)
+        assertEquals(EntityId(20), bond.right.moleculeId)
     }
 
     @Test
     fun `tryBind rejects and leaves registry unchanged when no complementary site exists`() {
         val binder = interpretedBinderFrom("AAKRGKAA")
-        val target = MRna.of("AAAAAAA").bindingSurface(MoleculeId(30))
+        val target = MRna.of("AAAAAAA").bindingSurface(EntityId(30))
         val registry = BondRegistry()
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(101),
+            proteinId = EntityId(101),
             binder = binder,
             target = target,
             registry = registry,
@@ -60,11 +60,11 @@ class ProteinBindingTest {
     @Test
     fun `tryBind rejects when affinity normalizes to inactive bond strength`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.0)
-        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(32))
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(EntityId(32))
         val registry = BondRegistry()
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(203),
+            proteinId = EntityId(203),
             binder = binder,
             target = target,
             registry = registry,
@@ -78,17 +78,17 @@ class ProteinBindingTest {
     fun `different amino acid context yields different binder target and different match site`() {
         val firstBinder = interpretedBinderFrom("AAKRGKAA")
         val secondBinder = interpretedBinderFrom("AAKRGKDA")
-        val target = MRna.of(buildTargetWithOnlySecondMatch(secondBinder.bindingPattern)).bindingSurface(MoleculeId(31))
+        val target = MRna.of(buildTargetWithOnlySecondMatch(secondBinder.bindingPattern)).bindingSurface(EntityId(31))
         val registry = BondRegistry()
 
         val firstBond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(201),
+            proteinId = EntityId(201),
             binder = firstBinder,
             target = target,
             registry = registry,
         )
         val secondBond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(202),
+            proteinId = EntityId(202),
             binder = secondBinder,
             target = target,
             registry = registry,
@@ -102,10 +102,10 @@ class ProteinBindingTest {
     @Test
     fun `weaker binder does not displace stronger overlapping bond`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.4)
-        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(40))
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(EntityId(40))
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
         val strongerOccupant = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(500)),
+            left = WholeMoleculeEndpoint(EntityId(500)),
             right = SiteEndpoint(targetSite),
             strength = 0.9,
             decayPerTick = 0.05,
@@ -113,7 +113,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(strongerOccupant))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(501),
+            proteinId = EntityId(501),
             binder = binder,
             target = target,
             registry = registry,
@@ -126,10 +126,10 @@ class ProteinBindingTest {
     @Test
     fun `stronger binder displaces weaker overlapping bond`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.9)
-        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(41))
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(EntityId(41))
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
         val weakerOccupant = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(510)),
+            left = WholeMoleculeEndpoint(EntityId(510)),
             right = SiteEndpoint(targetSite),
             strength = 0.3,
             decayPerTick = 0.05,
@@ -137,7 +137,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(weakerOccupant))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(511),
+            proteinId = EntityId(511),
             binder = binder,
             target = target,
             registry = registry,
@@ -150,16 +150,16 @@ class ProteinBindingTest {
     @Test
     fun `non-overlapping bonds remain when overlapping weaker bond is displaced`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.8)
-        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CCAA").bindingSurface(MoleculeId(42))
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CCAA").bindingSurface(EntityId(42))
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
         val overlappingWeak = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(520)),
+            left = WholeMoleculeEndpoint(EntityId(520)),
             right = SiteEndpoint(targetSite),
             strength = 0.4,
             decayPerTick = 0.05,
         )
         val nonOverlapping = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(521)),
+            left = WholeMoleculeEndpoint(EntityId(521)),
             right = SiteEndpoint(target.site(targetSite.range.endExclusive, target.length)),
             strength = 0.9,
             decayPerTick = 0.05,
@@ -167,7 +167,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(overlappingWeak, nonOverlapping))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(522),
+            proteinId = EntityId(522),
             binder = binder,
             target = target,
             registry = registry,
@@ -182,10 +182,10 @@ class ProteinBindingTest {
     @Test
     fun `equal strength overlap keeps existing bond deterministically`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.6)
-        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(43))
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(EntityId(43))
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
         val existing = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(530)),
+            left = WholeMoleculeEndpoint(EntityId(530)),
             right = SiteEndpoint(targetSite),
             strength = 0.6,
             decayPerTick = 0.05,
@@ -193,7 +193,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(existing))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(531),
+            proteinId = EntityId(531),
             binder = binder,
             target = target,
             registry = registry,
@@ -207,10 +207,10 @@ class ProteinBindingTest {
     @Test
     fun `sub-epsilon affinity still displaces weaker overlap`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 5.0e-10)
-        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(MoleculeId(45))
+        val target = MRna.of("UUG${asText(binder.bindingPattern.complement())}CC").bindingSurface(EntityId(45))
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
         val weakerOccupant = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(550)),
+            left = WholeMoleculeEndpoint(EntityId(550)),
             right = SiteEndpoint(targetSite),
             strength = 1.0e-12,
             decayPerTick = 0.05,
@@ -218,7 +218,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(weakerOccupant))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(551),
+            proteinId = EntityId(551),
             binder = binder,
             target = target,
             registry = registry,
@@ -232,25 +232,25 @@ class ProteinBindingTest {
     @Test
     fun `multiple overlapping weaker occupants are displaced together`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.95)
-        val target = MRna.of("UU${asText(binder.bindingPattern.complement())}GG").bindingSurface(MoleculeId(44))
+        val target = MRna.of("UU${asText(binder.bindingPattern.complement())}GG").bindingSurface(EntityId(44))
         val targetSite = BindingMatcher.complementaryMatchSite(binder.bindingPattern, target)!!
 
         val overlappingFirst = Bond(
             left = SiteEndpoint(target.site(targetSite.range.start, targetSite.range.start + 2)),
-            right = WholeMoleculeEndpoint(MoleculeId(540)),
+            right = WholeMoleculeEndpoint(EntityId(540)),
             strength = 0.3,
             decayPerTick = 0.05,
         )
         val overlappingSecond = Bond(
             left = SiteEndpoint(target.site(targetSite.range.endExclusive - 2, targetSite.range.endExclusive)),
-            right = WholeMoleculeEndpoint(MoleculeId(541)),
+            right = WholeMoleculeEndpoint(EntityId(541)),
             strength = 0.4,
             decayPerTick = 0.05,
         )
         val registry = BondRegistry(listOf(overlappingFirst, overlappingSecond))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(542),
+            proteinId = EntityId(542),
             binder = binder,
             target = target,
             registry = registry,
@@ -264,10 +264,10 @@ class ProteinBindingTest {
     fun `tryBind skips first blocked matching site and binds at second viable site`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.7)
         val target = MRna.of("AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG")
-            .bindingSurface(MoleculeId(560))
+            .bindingSurface(EntityId(560))
         val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
         val blockedFirst = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(561)),
+            left = WholeMoleculeEndpoint(EntityId(561)),
             right = SiteEndpoint(matchingSites.first()),
             strength = 0.9,
             decayPerTick = 0.05,
@@ -275,7 +275,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(blockedFirst))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(562),
+            proteinId = EntityId(562),
             binder = binder,
             target = target,
             registry = registry,
@@ -292,16 +292,16 @@ class ProteinBindingTest {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.7)
         val target = MRna.of(
             "AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG${asText(binder.bindingPattern.complement())}UU",
-        ).bindingSurface(MoleculeId(570))
+        ).bindingSurface(EntityId(570))
         val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
         val blockedFirst = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(571)),
+            left = WholeMoleculeEndpoint(EntityId(571)),
             right = SiteEndpoint(matchingSites[0]),
             strength = 0.8,
             decayPerTick = 0.05,
         )
         val blockedSecond = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(572)),
+            left = WholeMoleculeEndpoint(EntityId(572)),
             right = SiteEndpoint(matchingSites[1]),
             strength = 0.9,
             decayPerTick = 0.05,
@@ -309,7 +309,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(blockedFirst, blockedSecond))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(573),
+            proteinId = EntityId(573),
             binder = binder,
             target = target,
             registry = registry,
@@ -324,16 +324,16 @@ class ProteinBindingTest {
     fun `tryBind returns null when all matching sites are blocked by equal or stronger overlaps`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.7)
         val target = MRna.of("AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG")
-            .bindingSurface(MoleculeId(580))
+            .bindingSurface(EntityId(580))
         val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
         val blockedFirst = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(581)),
+            left = WholeMoleculeEndpoint(EntityId(581)),
             right = SiteEndpoint(matchingSites[0]),
             strength = 0.7,
             decayPerTick = 0.05,
         )
         val blockedSecond = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(582)),
+            left = WholeMoleculeEndpoint(EntityId(582)),
             right = SiteEndpoint(matchingSites[1]),
             strength = 0.95,
             decayPerTick = 0.05,
@@ -341,7 +341,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(blockedFirst, blockedSecond))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(583),
+            proteinId = EntityId(583),
             binder = binder,
             target = target,
             registry = registry,
@@ -355,16 +355,16 @@ class ProteinBindingTest {
     fun `tryBind displaces weaker overlap at later viable site while scanning`() {
         val binder = interpretedBinderFrom("AAKRGKAA").copy(affinity = 0.8)
         val target = MRna.of("AA${asText(binder.bindingPattern.complement())}CC${asText(binder.bindingPattern.complement())}GG")
-            .bindingSurface(MoleculeId(590))
+            .bindingSurface(EntityId(590))
         val matchingSites = BindingMatcher.complementaryMatchSites(binder.bindingPattern, target).toList()
         val strongFirst = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(591)),
+            left = WholeMoleculeEndpoint(EntityId(591)),
             right = SiteEndpoint(matchingSites[0]),
             strength = 0.9,
             decayPerTick = 0.05,
         )
         val weakSecond = Bond(
-            left = WholeMoleculeEndpoint(MoleculeId(592)),
+            left = WholeMoleculeEndpoint(EntityId(592)),
             right = SiteEndpoint(matchingSites[1]),
             strength = 0.3,
             decayPerTick = 0.05,
@@ -372,7 +372,7 @@ class ProteinBindingTest {
         val registry = BondRegistry(listOf(strongFirst, weakSecond))
 
         val bond = ProteinBinding.tryBind(
-            proteinId = MoleculeId(593),
+            proteinId = EntityId(593),
             binder = binder,
             target = target,
             registry = registry,

--- a/docs/biology/interactions/bonds.md
+++ b/docs/biology/interactions/bonds.md
@@ -129,7 +129,7 @@ classDiagram
         +overlaps(other)
     }
 
-    class MoleculeId {
+    class EntityId {
         +Long value
     }
 
@@ -141,7 +141,7 @@ classDiagram
     }
 
     class BindingSurface {
-        +MoleculeId moleculeId
+        +EntityId moleculeId
         +BindingStrand strand
         +NucleotideSequence sequence
         +Int length
@@ -152,7 +152,7 @@ classDiagram
     class BindingSite {
         +BindingSurface surface
         +SequenceRange range
-        +MoleculeId moleculeId
+        +EntityId moleculeId
         +BindingStrand strand
         +NucleotideSequence sequence
         +sameSurfaceAs(other)
@@ -161,7 +161,7 @@ classDiagram
 
     class BondEndpoint {
         <<interface>>
-        +MoleculeId moleculeId
+        +EntityId moleculeId
         +BindingSite? site
     }
 
@@ -170,7 +170,7 @@ classDiagram
     }
 
     class WholeMoleculeEndpoint {
-        +MoleculeId moleculeId
+        +EntityId moleculeId
     }
 
     class Bond {
@@ -195,7 +195,7 @@ classDiagram
 
     BondEndpoint <|.. SiteEndpoint
     BondEndpoint <|.. WholeMoleculeEndpoint
-    BindingSurface --> MoleculeId
+    BindingSurface --> EntityId
     BindingSurface --> BindingStrand
     BindingSite --> BindingSurface
     BindingSite --> SequenceRange
@@ -248,8 +248,8 @@ Conflict resolution still happens inside `ProteinBinding` by mutating `BondRegis
 ## Example: creating different bond kinds
 
 ```kotlin
-val dnaSurface = dna.forwardBindingSurface(MoleculeId(11))
-val rnaSurface = mrna.bindingSurface(MoleculeId(12))
+val dnaSurface = dna.forwardBindingSurface(EntityId(11))
+val rnaSurface = mrna.bindingSurface(EntityId(12))
 
 val siteToSite = Bond(
     left = SiteEndpoint(dnaSurface.site(3, 8)),
@@ -260,14 +260,14 @@ val siteToSite = Bond(
 
 val siteToWhole = Bond(
     left = SiteEndpoint(dnaSurface.site(8, 12)),
-    right = WholeMoleculeEndpoint(MoleculeId(99)),
+    right = WholeMoleculeEndpoint(EntityId(99)),
     strength = 0.7,
     decayPerTick = 0.08,
 )
 
 val wholeToWhole = Bond(
-    left = WholeMoleculeEndpoint(MoleculeId(99)),
-    right = WholeMoleculeEndpoint(MoleculeId(100)),
+    left = WholeMoleculeEndpoint(EntityId(99)),
+    right = WholeMoleculeEndpoint(EntityId(100)),
     strength = 0.6,
     decayPerTick = 0.03,
 )

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -122,7 +122,7 @@ carry concrete sequence targets that can be used during runtime matching.
 
 When a protein needs to exist as an explicit runtime molecule, `ActiveProtein` can be created with:
 
-- `moleculeId: MoleculeId` (stable runtime identity)
+- `moleculeId: EntityId` (stable runtime identity; `EntityId` remains a compatibility alias)
 - `source: Polypeptide` (the source amino-acid chain)
 - `domains: List<ProteinDomain>` (preserved interpreted domains)
 - `capabilities: List<MolecularCapability>` (flattened capabilities derived from `domains`)
@@ -141,7 +141,7 @@ Runtime occupancy and binding state are modeled separately by the interactions l
 The `ProteinBinding.tryBind(...)` helper bridges interpretation to runtime associations by using a
 `SequenceBinder` pattern plus `BindingMatcher` to create and register concrete `Bond` values.
 `ActiveProtein` complements this by preserving interpreted domains/capabilities alongside the
-protein's stable runtime `MoleculeId`.
+protein's stable runtime `EntityId` (with `EntityId` kept as a compatibility alias).
 
 That separation allows molecule values to remain immutable while runtime systems track transient binding dynamics.
 

--- a/docs/biology/molecules.md
+++ b/docs/biology/molecules.md
@@ -122,7 +122,7 @@ carry concrete sequence targets that can be used during runtime matching.
 
 When a protein needs to exist as an explicit runtime molecule, `ActiveProtein` can be created with:
 
-- `moleculeId: EntityId` (stable runtime identity; `EntityId` remains a compatibility alias)
+- `moleculeId: EntityId` (stable runtime identity)
 - `source: Polypeptide` (the source amino-acid chain)
 - `domains: List<ProteinDomain>` (preserved interpreted domains)
 - `capabilities: List<MolecularCapability>` (flattened capabilities derived from `domains`)
@@ -141,7 +141,7 @@ Runtime occupancy and binding state are modeled separately by the interactions l
 The `ProteinBinding.tryBind(...)` helper bridges interpretation to runtime associations by using a
 `SequenceBinder` pattern plus `BindingMatcher` to create and register concrete `Bond` values.
 `ActiveProtein` complements this by preserving interpreted domains/capabilities alongside the
-protein's stable runtime `EntityId` (with `EntityId` kept as a compatibility alias).
+protein's stable runtime `EntityId`.
 
 That separation allows molecule values to remain immutable while runtime systems track transient binding dynamics.
 

--- a/docs/biology/proteins.md
+++ b/docs/biology/proteins.md
@@ -13,7 +13,7 @@ Protein-package types:
 - `ProteinInterpreter` — maps `Polypeptide` motifs to interpreted `ProteinDomain` hits
 - `ProteinDomain` — one interpreted motif hit with source span and capabilities
 - `MolecularCapability` — sealed runtime capability model (`SequenceBinder`, `Cutter`, `Ligase`, `Blocker`)
-- `ActiveProtein` — first-class runtime protein value with stable `MoleculeId`, source chain, interpreted domains, and flattened capabilities
+- `ActiveProtein` — first-class runtime protein value with stable `EntityId`, source chain, interpreted domains, and flattened capabilities
 - `ProteinBinding` — helper that turns `SequenceBinder` capabilities into concrete `Bond` associations
 
 ---
@@ -69,7 +69,7 @@ Each capability also exposes a string `kind` value for lightweight runtime class
 
 `ActiveProtein` is the runtime protein aggregate:
 
-- `moleculeId: MoleculeId`
+- `moleculeId: EntityId`
 - `source: Polypeptide`
 - `domains: List<ProteinDomain>`
 - `capabilities: List<MolecularCapability>`


### PR DESCRIPTION
### Motivation
- Standardize the runtime identifier name used by the interactions layer to a more generic `EntityId` to decouple identity from the `Molecule` naming and improve clarity of runtime entity identity.

### Description
- Add a new inline value class `EntityId` and remove the old `MoleculeId` type, updating all interaction types to use `EntityId` (e.g. `BindingSurface`, `BindingSite`, `BondEndpoint`, `WholeMoleculeEndpoint`, `Bond`, and `BondRegistry`).
- Update runtime protein types to use `EntityId` (e.g. `ActiveProtein`) and adjust molecule binding helpers (e.g. `Dna`/`MRna`/`TRna` binding surface helpers) to accept `EntityId`.
- Update tests and documentation examples to reflect the renamed type and keep all behavior and APIs otherwise unchanged.

### Testing
- Ran the biology unit test suite including `BindingSiteTest`, `BondTest`, `BondRegistryTest`, `BindingMatcherTest`, `ProteinBindingTest`, `ActiveProteinTest`, and `BindingAvailabilityEventsTest`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a050e0aa34c8329b9421e36cec719f2)